### PR TITLE
Fix ghost TTS hearing

### DIFF
--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -57,6 +57,7 @@
 			track += "(<a href='byond://?src=\ref[src];track=\ref[queen_eye]'>E</a>) "
 	if(client && client.prefs && client.prefs.toggles_chat & CHAT_GHOSTEARS && speaker.z == z && get_dist(speaker, src) <= GLOB.world_view_size)
 		message = "<b>[message]</b>"
+		speaker.cast_tts(client, message) // SS220 ADDITION
 
 	to_chat(src, "<span class='game say'><span class='name'>[comm_paygrade][speaker_name]</span>[alt_name] [track][verb], <span class='message'><span class='[style]'>\"[message]\"</span></span></span>")
 	if (speech_sound && (get_dist(speaker, src) <= GLOB.world_view_size && src.z == speaker.z))


### PR DESCRIPTION
Closes https://github.com/ss220club/BandaMarines/issues/19

Фикс слышимости ТТС у гостов. Я не знаю что я делаю и работает ли оно.

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where ghost text-to-speech was not audible to other players.