### PR TITLE
Fix ghost TTS hearing

### DIFF
--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -57,6 +57,7 @@
 			track += "(<a href='byond://?src=\ref[src];track=\ref[queen_eye]'>E</a>) "
 	if(client && client.prefs && client.prefs.toggles_chat & CHAT_GHOSTEARS && speaker.z == z && get_dist(speaker, src) <= GLOB.world_view_size)
 		message = "<b>[message]</b>"
+		speaker.cast_tts(src, message) // SS220 ADDITION
 
 	to_chat(src, "<span class='game say'><span class='name'>[comm_paygrade][speaker_name]</span>[alt_name] [track][verb], <span class='message'><span class='[style]'>\"[message]\"</span></span></span>")
 	if (speech_sound && (get_dist(speaker, src) <= GLOB.world_view_size && src.z == speaker.z))


### PR DESCRIPTION
Попытка №2 пофиксить слышимость ТТС. Теперь с форка.

## Summary by Sourcery

Bug Fixes:
- Allow ghosts to hear TTS messages from other ghosts.