### PR TITLE
Tweak linter and fix some warnings

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -13,4 +13,3 @@ engine = "auxtools"
 
 [diagnostics]
 var_in_proc_parameter = "error"
-redefined_proc = "warning"

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -316,7 +316,7 @@
 
 /datum/controller/configuration/proc/LoadChatFilter()
 	return load_ss220_filters()	// SS220 ADD - Cyrillic speach filter
-
+	/*	SS220 REMOVE - Cyrillic speach filter
 	var/list/word_filter = list()
 
 	if(!fexists("[directory]/word_filter.txt"))
@@ -332,6 +332,7 @@
 		word_filter += REGEX_QUOTE(line)
 
 	word_filter_regex = length(word_filter) ? regex("\\b([jointext(word_filter, "|")])\\b", "i") : null
+	SS220 REMOVE - Cyrillic speach filter */
 
 //Message admins when you can.
 /datum/controller/configuration/proc/DelayedMessageAdmins(text)

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -315,8 +315,8 @@
 
 
 /datum/controller/configuration/proc/LoadChatFilter()
-	return load_ss220_filters()	// SS220 ADD - Cyrillic speach filter
-	/*	SS220 REMOVE - Cyrillic speach filter
+	return load_ss220_filters()	// SS220 ADD - Cyrillic speech filter
+	/*	SS220 REMOVE - Cyrillic speech filter
 	var/list/word_filter = list()
 
 	if(!fexists("[directory]/word_filter.txt"))
@@ -332,7 +332,7 @@
 		word_filter += REGEX_QUOTE(line)
 
 	word_filter_regex = length(word_filter) ? regex("\\b([jointext(word_filter, "|")])\\b", "i") : null
-	SS220 REMOVE - Cyrillic speach filter */
+	SS220 REMOVE - Cyrillic speech filter */
 
 //Message admins when you can.
 /datum/controller/configuration/proc/DelayedMessageAdmins(text)

--- a/code/defines/procs/announcement.dm
+++ b/code/defines/procs/announcement.dm
@@ -167,7 +167,7 @@
 
 //the announcement proc that handles announcing for each mob in targets list
 /proc/announcement_helper(message, title, list/targets, sound_to_play,
-									var/datum/announcer/announcer = TTS_DEFAULT_ANNOUNCER)	// SS220 EDIT - TTS
+									datum/announcer/announcer = TTS_DEFAULT_ANNOUNCER)	// SS220 EDIT - TTS
 	if(!message || !title || !sound_to_play || !targets) //Shouldn't happen
 		return
 	for(var/mob/T in targets)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -67,7 +67,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 /proc/filter_message(client/user, message)
 
 	return config.filter_speech(user, message) // SS220 ADD - Cyrillic Speach Filter
-
+	/* SS220 REMOVE - Cyrillic speach filter
 	if(!config.word_filter_regex)
 		return TRUE
 
@@ -84,6 +84,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		return FALSE
 
 	return TRUE
+	SS220 REMOVE - Cyrillic speach filter */
 
 ///Shows custom speech bubbles for screaming, *warcry etc.
 /mob/living/proc/show_speech_bubble(bubble_name, bubble_type = bubble_icon)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -66,8 +66,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 /proc/filter_message(client/user, message)
 
-	return config.filter_speech(user, message) // SS220 ADD - Cyrillic Speach Filter
-	/* SS220 REMOVE - Cyrillic speach filter
+	return config.filter_speech(user, message) // SS220 ADD - Cyrillic speech Filter
+	/* SS220 REMOVE - Cyrillic speech filter
 	if(!config.word_filter_regex)
 		return TRUE
 
@@ -84,7 +84,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		return FALSE
 
 	return TRUE
-	SS220 REMOVE - Cyrillic speach filter */
+	SS220 REMOVE - Cyrillic speech filter */
 
 ///Shows custom speech bubbles for screaming, *warcry etc.
 /mob/living/proc/show_speech_bubble(bubble_name, bubble_type = bubble_icon)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -269,10 +269,10 @@ CLIENT_ERROR_VERSION 514
 ## =====================================
 ## SS220
 ## TTS
-tts_enabled
-tts_token_silero
-tts_cache_enabled
-ffmpeg_cpuaffinity
-tts_api_url_silero
+#tts_enabled
+#tts_token_silero
+#tts_cache_enabled
+#ffmpeg_cpuaffinity
+#tts_api_url_silero
 
 ## =====================================


### PR DESCRIPTION
# About the pull request
Убирает предупреждение о редефайне проков и исправляет пару предупреждений
Выключает ТТС в конфиге по умолчанию
# Explain why it's good for the game
Меньше бесполезных предупреждений в линтере


# Testing Photographs and Procedure
![image](https://github.com/user-attachments/assets/16f8595d-8735-4d79-82de-5502ecb63d08)

## Summary by Sourcery

Remove the Cyrillic speech filter and fix a few linter warnings about redefined procs and a variable used as a proc parameter.

Bug Fixes:
- Removed the Cyrillic speech filter.

Enhancements:
- Fixed linter warnings about a redefined proc and a variable used as a proc parameter.