### PR TITLE
Sentinel translate + WHY IS IT STILL IN 2 SECOND WAIT LIFE

### DIFF
--- a/modular/translations/code/xeno/xeno_abilities/castes/crusher.dm
+++ b/modular/translations/code/xeno/xeno_abilities/castes/crusher.dm
@@ -9,7 +9,7 @@
 	replace_in_desc("%ARMOR%", 15) // Hardcoded
 	replace_in_desc("%DAMAGE%", direct_hit_damage)
 	replace_in_desc("%SLOWDOWN%", 3.5, DESCRIPTION_REPLACEMENT_TIME) // Hardcoded
-	replace_in_desc("%KNOCKDOWN%", 2, DESCRIPTION_REPLACEMENT_TIME) // Hardcoded
+	replace_in_desc("%KNOCKDOWN%", convert_effect_time(2, WEAKEN), DESCRIPTION_REPLACEMENT_TIME) // Hardcoded
 	replace_in_desc("%THROW%", 3, DESCRIPTION_REPLACEMENT_DISTANCE) // Hardcoded
 
 /datum/action/xeno_action/onclick/crusher_stomp
@@ -17,8 +17,8 @@
 
 /datum/action/xeno_action/onclick/crusher_stomp/apply_replaces_in_desc()
 	replace_in_desc("%DAMAGE%", 60)
-	replace_in_desc("%SLOWTIME%", effect_duration / 10, DESCRIPTION_REPLACEMENT_TIME)
-	replace_in_desc("%KNOCKDOWN%", 0.2, DESCRIPTION_REPLACEMENT_TIME)
+	replace_in_desc("%SLOWTIME%", effect_duration / 10, DESCRIPTION_REPLACEMENT_TIME) // It's decimeters
+	replace_in_desc("%KNOCKDOWN%", convert_effect_time(0.2, WEAKEN), DESCRIPTION_REPLACEMENT_TIME)
 	replace_in_desc("%KNOCKDOWN_DISTANCE%", distance, DESCRIPTION_REPLACEMENT_DISTANCE)
 
 /datum/action/xeno_action/onclick/crusher_stomp/charger
@@ -51,5 +51,5 @@
 	desc = "Сделать уворок в бок. Сбрасывает моментум, но после окончания уворот моментум начнёт накапливаться сразу же. При попадании опрокидывает цель (%WEAKEN%) и наносит %DAMAGE% урона."
 
 /datum/action/xeno_action/activable/tumble/apply_replaces_in_desc()
-	replace_in_desc("%WEAKEN%", 1, DESCRIPTION_REPLACEMENT_TIME)
+	replace_in_desc("%WEAKEN%", convert_effect_time(1, WEAKEN), DESCRIPTION_REPLACEMENT_TIME)
 	replace_in_desc("%DAMAGE%", 15) // Hardcoded

--- a/modular/translations/code/xeno/xeno_abilities/castes/crusher.dm
+++ b/modular/translations/code/xeno/xeno_abilities/castes/crusher.dm
@@ -17,7 +17,7 @@
 
 /datum/action/xeno_action/onclick/crusher_stomp/apply_replaces_in_desc()
 	replace_in_desc("%DAMAGE%", 60)
-	replace_in_desc("%SLOWTIME%", effect_duration / 10, DESCRIPTION_REPLACEMENT_TIME) // It's decimeters
+	replace_in_desc("%SLOWTIME%", effect_duration / 10, DESCRIPTION_REPLACEMENT_TIME) // It's deciseconds
 	replace_in_desc("%KNOCKDOWN%", convert_effect_time(0.2, WEAKEN), DESCRIPTION_REPLACEMENT_TIME)
 	replace_in_desc("%KNOCKDOWN_DISTANCE%", distance, DESCRIPTION_REPLACEMENT_DISTANCE)
 

--- a/modular/translations/code/xeno/xeno_abilities/castes/sentinel.dm
+++ b/modular/translations/code/xeno/xeno_abilities/castes/sentinel.dm
@@ -1,5 +1,20 @@
 /datum/action/xeno_action/activable/slowing_spit
+	desc = "Слабый нейротоксин ограниченной дистанции (%DISTANCE%). Значительно замедляет цель (%SLOWDOWN%). Носитель может устоять от нейротоксина."
+
+/datum/action/xeno_action/activable/slowing_spit/apply_replaces_in_desc()
+	replace_in_desc("%DISTANCE%", /datum/ammo/xeno/toxin::max_range, DESCRIPTION_REPLACEMENT_DISTANCE)
+	replace_in_desc("%SLOWDOWN%", convert_effect_time(4, SUPERSLOW), DESCRIPTION_REPLACEMENT_TIME)
 
 /datum/action/xeno_action/activable/scattered_spit
+	desc = "Слабый нейротоксин ограниченной дистанции (%DISTANCE%), стреляющий веером. Кратковременно оглушает цель (%STUN%). Носитель может устоять от нейротоксина."
+
+/datum/action/xeno_action/activable/scattered_spit/apply_replaces_in_desc()
+	replace_in_desc("%DISTANCE%", /datum/ammo/xeno/toxin/shotgun::max_range, DESCRIPTION_REPLACEMENT_DISTANCE)
+	replace_in_desc("%STUN%", convert_effect_time(0.7, STUN), DESCRIPTION_REPLACEMENT_TIME)
 
 /datum/action/xeno_action/onclick/paralyzing_slash
+	desc = "Усиливает следующий удар. При попадании цель будет дезориентирована (%DAZE%), а также через 3 сек. цель будет оглушена (%STUN%) Носитель может устоять от нейротоксина."
+
+/datum/action/xeno_action/onclick/paralyzing_slash/apply_replaces_in_desc()
+	replace_in_desc("%DAZE%", convert_effect_time(4, DAZE), DESCRIPTION_REPLACEMENT_TIME)
+	replace_in_desc("%STUN%", convert_effect_time(2.5, STUN), DESCRIPTION_REPLACEMENT_TIME)

--- a/modular/translations/code/xeno/xeno_abilities/castes/warrior.dm
+++ b/modular/translations/code/xeno/xeno_abilities/castes/warrior.dm
@@ -2,8 +2,8 @@
 	desc = "Кинуть цель вперёд от вас (%FLING_DISTANCE%). Оглушает цель (%FLING_STUN%). Замедляет цель (%FLING_SLOWDOWN%)."
 
 /datum/action/xeno_action/activable/fling/apply_replaces_in_desc()
-	replace_in_desc("%FLING_STUN%", stun_power, DESCRIPTION_REPLACEMENT_TIME)
-	replace_in_desc("%FLING_SLOWDOWN%", slowdown, DESCRIPTION_REPLACEMENT_TIME)
+	replace_in_desc("%FLING_STUN%", convert_effect_time(stun_power, STUN), DESCRIPTION_REPLACEMENT_TIME)
+	replace_in_desc("%FLING_SLOWDOWN%", convert_effect_time(slowdown, SLOW), DESCRIPTION_REPLACEMENT_TIME)
 	replace_in_desc("%FLING_DISTANCE%", fling_distance, DESCRIPTION_REPLACEMENT_DISTANCE)
 
 /datum/action/xeno_action/activable/lunge
@@ -11,7 +11,7 @@
 
 /datum/action/xeno_action/activable/lunge/apply_replaces_in_desc()
 	replace_in_desc("%LUNGE_DISTANCE%", grab_range, DESCRIPTION_REPLACEMENT_DISTANCE)
-	replace_in_desc("%LUNGE_STUN%", 2, DESCRIPTION_REPLACEMENT_TIME) // Hardcoded in warrior's grab code
+	replace_in_desc("%LUNGE_STUN%", convert_effect_time(2, STUN), DESCRIPTION_REPLACEMENT_TIME) // Hardcoded in warrior's grab code
 
 /datum/action/xeno_action/activable/warrior_punch
 	desc = "Отталкивающий удар, наносящий %PUNCH_DAMAGE_MIN%-%PUNCH_DAMAGE_MAX% урона. Разрушает шины на конечности. Замедляет цель (%PUNCH_SLOWDOWN%). На мгновение дезориентирует цель."
@@ -19,4 +19,4 @@
 /datum/action/xeno_action/activable/warrior_punch/apply_replaces_in_desc()
 	replace_in_desc("%PUNCH_DAMAGE_MIN%", base_damage)
 	replace_in_desc("%PUNCH_DAMAGE_MAX%", base_damage + damage_variance)
-	replace_in_desc("%PUNCH_SLOWDOWN%", 3) // Hardcoded
+	replace_in_desc("%PUNCH_SLOWDOWN%", convert_effect_time(3, SLOW)) // Hardcoded

--- a/modular/translations/code/xeno/xeno_abilities/castes/warrior.dm
+++ b/modular/translations/code/xeno/xeno_abilities/castes/warrior.dm
@@ -19,4 +19,4 @@
 /datum/action/xeno_action/activable/warrior_punch/apply_replaces_in_desc()
 	replace_in_desc("%PUNCH_DAMAGE_MIN%", base_damage)
 	replace_in_desc("%PUNCH_DAMAGE_MAX%", base_damage + damage_variance)
-	replace_in_desc("%PUNCH_SLOWDOWN%", convert_effect_time(3, SLOW)) // Hardcoded
+	replace_in_desc("%PUNCH_SLOWDOWN%", convert_effect_time(3, SLOW), DESCRIPTION_REPLACEMENT_TIME) // Hardcoded

--- a/modular/translations/code/xeno/xeno_abilities/xeno_action.dm
+++ b/modular/translations/code/xeno/xeno_abilities/xeno_action.dm
@@ -36,6 +36,6 @@
 		if(STUN, DAZE, WEAKEN)
 			return amount * GLOBAL_STATUS_MULTIPLIER / 10
 		if(SLOW, SUPERSLOW, SLUR, STUTTER)
-			// SLOW STATUS EFFECT IS DIFFERENT. It uses decimeters.
+			// SLOW STATUS EFFECT IS DIFFERENT. It uses deciseconds.
 			return amount * /datum/controller/subsystem/human::wait / 10
 	return amount

--- a/modular/translations/code/xeno/xeno_abilities/xeno_action.dm
+++ b/modular/translations/code/xeno/xeno_abilities/xeno_action.dm
@@ -29,3 +29,12 @@
 		desc += "<br>Перезарядка: [round(xeno_cooldown / 10, 0.1)] сек."
 	if(charge_time)
 		desc += "<br>Задержка перед активацией: [round(charge_time / 10, 0.1)] сек."
+
+/// Helper proc to make time make sense
+/datum/action/xeno_action/proc/convert_effect_time(amount, status)
+	switch(status)
+		if(STUN, DAZE, WEAKEN)
+			return amount * GLOBAL_STATUS_MULTIPLIER / 10
+		if(SLOW, SUPERSLOW, SLUR, STUTTER)
+			return amount * /datum/controller/subsystem/human::wait / 10
+	return amount

--- a/modular/translations/code/xeno/xeno_abilities/xeno_action.dm
+++ b/modular/translations/code/xeno/xeno_abilities/xeno_action.dm
@@ -6,11 +6,11 @@
 /datum/action/xeno_action/proc/replace_in_desc(what_to_replace, replace_with, type)
 	switch(type)
 		if(DESCRIPTION_REPLACEMENT_TIME)
-			desc = replacetext_char(desc, what_to_replace, "[round(replace_with, 0.1)] сек.")
+			desc = replacetext_char(desc, what_to_replace, "<b>[round(replace_with, 0.1)] сек.</b>")
 		if(DESCRIPTION_REPLACEMENT_DISTANCE)
-			desc = replacetext_char(desc, what_to_replace, "[replace_with] кл.")
+			desc = replacetext_char(desc, what_to_replace, "<b>[replace_with] кл.</b>")
 		else
-			desc = replacetext_char(desc, what_to_replace, replace_with)
+			desc = replacetext_char(desc, what_to_replace, "<b>[replace_with]</b>")
 
 /// Called when something changes and we need to reconstruct description
 /datum/action/xeno_action/proc/update_desc()
@@ -36,5 +36,6 @@
 		if(STUN, DAZE, WEAKEN)
 			return amount * GLOBAL_STATUS_MULTIPLIER / 10
 		if(SLOW, SUPERSLOW, SLUR, STUTTER)
+			// SLOW STATUS EFFECT IS DIFFERENT. It uses decimeters.
 			return amount * /datum/controller/subsystem/human::wait / 10
 	return amount


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Перевод абилок сентинеля
Добавлен хелпер для перевода значений эффектов (стан, замедло) в секунды. ПОЧЕМУ ОНИ ВСЕ ЕЩЕ ИСПОЛЬЗУЮТ ЛАЙФ.

## Summary by Sourcery

Translate sentinel abilities and add a helper proc to convert effect values to seconds.

New Features:
- Added a helper proc to convert effect time values to seconds.

Tests:
- Updated tests for sentinel abilities.