### PR TITLE
Xeno stuff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -29,15 +29,24 @@ GLOBAL_LIST_EMPTY(deevolved_ckeys)
 	if(!length(castes_available))
 		to_chat(src, SPAN_WARNING("The Hive is not capable of supporting any castes we can evolve to yet."))
 		return
+
+	// BANDAMARINES EDIT START - Translation
+	// Assoc list - [ru_caste_name = caste_name]
+	var/list/castes_available_ru = list()
+	for(var/caste_name in castes_available)
+		castes_available_ru[declent_ru_initial(caste_name, NOMINATIVE, caste_name)] = caste_name
+	// BANDAMARINES EDIT END - Translation
+
 	var/castepick
 	if((client.prefs && client.prefs.no_radials_preference) || !hive.evolution_menu_images)
-		castepick = tgui_input_list(usr, "You are growing into a beautiful alien! It is time to choose a caste.", "Evolve", castes_available, theme="hive_status")
+		castepick = tgui_input_list(usr, "You are growing into a beautiful alien! It is time to choose a caste.", "Evolve", castes_available_ru, theme="hive_status") // BANDAMARINES EDIT - Translation
 	else
 		var/list/fancy_caste_list = list()
-		for(var/caste in castes_available)
-			fancy_caste_list[caste] = hive.evolution_menu_images[caste]
+		for(var/caste in castes_available_ru) // BANDAMARINES EDIT - Translation
+			fancy_caste_list[caste] = hive.evolution_menu_images[castes_available_ru[caste]] // BANDAMARINES EDIT - Translation
 
 		castepick = show_radial_menu(src, src.client?.eye, fancy_caste_list)
+	castepick = castes_available_ru[castepick] || castepick // BANDAMARINES EDIT - Translation
 	if(!castepick) //Changed my mind
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
@@ -40,7 +40,7 @@
  * If that can't be found, returns "Normal".
  */
 /mob/living/carbon/xenomorph/proc/get_strain_name()
-	return strain?.name || "Обычный"
+	return strain?.name || "Normal"
 
 /**
  * Returns the custom icon state from the xeno's strain, if it has one.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

fixes https://github.com/ss220club/BandaMarines/issues/52

Чинит икон стейт ови
Выбор касты полностью на русском языке

## Summary by Sourcery

Translate caste selection to Russian and fix the strain name to default to "Normal" instead of "Обычный".

Bug Fixes:
- Fixed the default strain name.

Enhancements:
- Translated the caste selection menu to Russian.