### PR TITLE
xeno names are ru

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -599,8 +599,8 @@
 		number_decorator = "Infernal "
 	if(show_name_numbers)
 		name_display = show_only_numbers ? " ([nicknumber])" : " ([name_client_prefix][nicknumber][name_client_postfix])"
-	name = "[name_prefix][number_decorator][age_display][caste.display_name || caste.caste_type][name_display]"
-	ru_names_rename(ru_names_toml(caste.display_name || caste.caste_type, prefix = "[name_prefix][number_decorator][age_display]", suffix = "[name_display]")) // BANDAMARINES ADDITION
+	name = "[name_prefix][number_decorator][age_display][declent_ru_initial(caste.display_name || caste.caste_type, NOMINATIVE, caste.display_name || caste.caste_type)][name_display]"
+	ru_names_rename(ru_names_toml(caste.display_name || caste.caste_type, prefix = "[name_prefix][number_decorator][age_display]", suffix = "[name_display]", override_base = name)) // BANDAMARINES ADDITION
 
 	//Update linked data so they show up properly
 	change_real_name(src, name)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Larva.dm
@@ -223,8 +223,8 @@ Also handles the "Mature / Bloody naming convention. Call this to update the nam
 	else if(larva_state == LARVA_STATE_BLOODY)
 		progress = "Кровавый "
 
-	name = "[name_prefix][progress]Larva ([nicknumber])"
-	ru_names_rename(ru_names_toml("Larva", prefix = "[name_prefix][progress]", suffix = " ([nicknumber])"))
+	name = "[name_prefix][progress][declent_ru_initial("Larva", NOMINATIVE, "Larva")] ([nicknumber])"
+	ru_names_rename(ru_names_toml("Larva", prefix = "[name_prefix][progress]", suffix = " ([nicknumber])", override_base = name))
 
 	//Update linked data so they show up properly
 	change_real_name(src, name)

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -457,30 +457,30 @@
 		age_xeno()
 		switch(age)
 			if(XENO_YOUNG)
-				name = "[name_prefix]Young Queen" //Young
-				ru_names_rename(ru_names_toml("Queen", "[name_prefix]Молодая ", override_base = "[name_prefix]Young Queen"))
+				name = "[name_prefix]Молодая [declent_ru_initial("Queen", NOMINATIVE, "Queen")]" //Young
+				ru_names_rename(ru_names_toml("Queen", "[name_prefix]Молодая ", override_base = name))
 			if(XENO_NORMAL)
-				name = "[name_prefix]Queen"  //Regular
-				ru_names_rename(ru_names_toml("Queen", "[name_prefix] ", override_base = "[name_prefix]Queen"))
+				name = "[name_prefix][declent_ru_initial("Queen", NOMINATIVE, "Queen")]"  //Regular
+				ru_names_rename(ru_names_toml("Queen", "[name_prefix]", override_base = name))
 			if(XENO_MATURE)
-				name = "[name_prefix]Elder Queen"  //Mature
-				ru_names_rename(ru_names_toml("Queen", "[name_prefix]Старшая ", override_base = "[name_prefix]Elder Queen"))
+				name = "[name_prefix]Старшая [declent_ru_initial("Queen", NOMINATIVE, "Queen")]"  //Mature
+				ru_names_rename(ru_names_toml("Queen", "[name_prefix]Старшая ", override_base = name))
 			if(XENO_ELDER)
-				name = "[name_prefix]Elder Empress"  //Elite
-				ru_names_rename(ru_names_toml("Empress", "[name_prefix]Старшая ", override_base = "[name_prefix]Elder Empress"))
+				name = "[name_prefix]Старшая [declent_ru_initial("Empress", NOMINATIVE, "Empress")]"  //Elite
+				ru_names_rename(ru_names_toml("Empress", "[name_prefix]Старшая ", override_base = name))
 			if(XENO_ANCIENT)
-				name = "[name_prefix]Ancient Empress" //Ancient
-				ru_names_rename(ru_names_toml("Empress", "[name_prefix]Древняя ", override_base = "[name_prefix]Ancient Empress"))
+				name = "[name_prefix]Древняя [declent_ru_initial("Empress", NOMINATIVE, "Empress")]" //Ancient
+				ru_names_rename(ru_names_toml("Empress", "[name_prefix]Древняя ", override_base = name))
 			if(XENO_PRIME)
-				name = "[name_prefix]Prime Empress" //Primordial
-				ru_names_rename(ru_names_toml("Empress", "[name_prefix]Прайм ", override_base = "[name_prefix]Prime Empress"))
+				name = "[name_prefix]Прайм [declent_ru_initial("Empress", NOMINATIVE, "Empress")]" //Primordial
+				ru_names_rename(ru_names_toml("Empress", "[name_prefix]Прайм ", override_base = name))
 	else
 		age = XENO_NORMAL
 		if(client)
 			hud_update()
 
-		name = "[name_prefix]Immature Queen"
-		ru_names_rename(ru_names_toml("Queen", "[name_prefix]Неокрепшая ", override_base = "[name_prefix]Immature Queen"))
+		name = "[name_prefix]Неокрепшая [declent_ru_initial("Queen", NOMINATIVE, "Queen")]"
+		ru_names_rename(ru_names_toml("Queen", "[name_prefix]Неокрепшая ", override_base = name))
 
 	var/name_client_prefix = ""
 	var/name_client_postfix = ""

--- a/modular/translations/code/ru_names/ru_name_base.dm
+++ b/modular/translations/code/ru_names/ru_name_base.dm
@@ -29,14 +29,20 @@ GLOBAL_LIST_EMPTY(ru_names)
 		GLOB.ru_names = rustg_read_toml_file("[PATH_TO_TRANSLATE_DATA]/ru_names.toml")
 	if(GLOB.ru_names[formatted_name])
 		var/base = override_base || "[prefix][name][suffix]"
+		var/nominative_form = GLOB.ru_names[formatted_name]["nominative"] || name
+		var/genitive_form = GLOB.ru_names[formatted_name]["genitive"] || nominative_form
+		var/dative_form = GLOB.ru_names[formatted_name]["dative"] || nominative_form
+		var/accusative_form = GLOB.ru_names[formatted_name]["accusative"] || nominative_form
+		var/instrumental_form = GLOB.ru_names[formatted_name]["instrumental"] || nominative_form
+		var/prepositional_form = GLOB.ru_names[formatted_name]["prepositional"] || nominative_form
 		. = ru_names_list(
 			base,
-			"[prefix][GLOB.ru_names[formatted_name]["nominative"] || name][suffix]",
-			"[prefix][GLOB.ru_names[formatted_name]["genitive"] || name][suffix]",
-			"[prefix][GLOB.ru_names[formatted_name]["dative"] || name][suffix]",
-			"[prefix][GLOB.ru_names[formatted_name]["accusative"] || name][suffix]",
-			"[prefix][GLOB.ru_names[formatted_name]["instrumental"] || name][suffix]",
-			"[prefix][GLOB.ru_names[formatted_name]["prepositional"] || name][suffix]",
+			"[prefix][nominative_form][suffix]",
+			"[prefix][genitive_form][suffix]",
+			"[prefix][dative_form][suffix]",
+			"[prefix][accusative_form][suffix]",
+			"[prefix][instrumental_form][suffix]",
+			"[prefix][prepositional_form][suffix]",
 			gender = "[GLOB.ru_names[formatted_name]["gender"] || null]",)
 
 /atom/Initialize(mapload, ...)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

Теперь имя ксеноты и настоящее имя тоже руссифицированы, чтобы не парить мозг

## Summary by Sourcery

Standardize xenomorph names in Russian.

New Features:
- Apply Russian declension rules to xenomorph names.

Tests:
- Update existing tests to reflect the xenomorph name changes.