### PR TITLE
FIX - TTS-radio volume and ERT sound volume 

### DIFF
--- a/modular/sounds/code/emergency_call.dm
+++ b/modular/sounds/code/emergency_call.dm
@@ -5,4 +5,4 @@
 
 	for(var/mob/dead/observer/M in GLOB.observer_list)
 		if(M.client)
-			M << sound('modular/sounds/sound/beeps_jingle.ogg', wait = 0, volume = 25) // SS220 ADD - ERT Sound
+			M << sound('modular/sounds/sound/beeps_jingle.ogg', wait = 0, volume = 50) // SS220 ADD - ERT Sound

--- a/modular/text_to_speech/code/sound.dm
+++ b/modular/text_to_speech/code/sound.dm
@@ -23,7 +23,7 @@
 /client/verb/adjust_volume_tts_radio()
 	set name = "Громкость TTS (Радио)"
 	set category = "Preferences.Sound"
-	adjust_volume_prefs(VOLUME_TTS_LOCAL, "Громкость TTS в радио", CHANNEL_TTS_RADIO)
+	adjust_volume_prefs(VOLUME_TTS_RADIO, "Громкость TTS в радио", CHANNEL_TTS_RADIO)
 
 /proc/get_rand_frequency()
 	return rand(32000, 55000) //Frequency stuff only works with 45kbps oggs.


### PR DESCRIPTION
Фиксим громкости вызова ЕРТ в гостах, а также фиксим настройку громкости для ТТС радио

## Summary by Sourcery

Fix the volume levels for ERT sound in observer mode and correct the TTS radio volume adjustment setting.

Bug Fixes:
- Fix the volume setting for ERT sound in observer mode by increasing it from 25 to 50.
- Correct the volume adjustment setting for TTS radio by using the appropriate volume constant.