### PR TITLE
Translate CLF Партизан

### DIFF
--- a/code/__DEFINES/bandamarines/ru_jobs.dm
+++ b/code/__DEFINES/bandamarines/ru_jobs.dm
@@ -270,7 +270,7 @@
 #define JOB_UPP_COMMISSAR_RU "СПН Политрук"
 
 //-------- CLF --------//
-#define JOB_CLF_RU "КОФ Бугай"	// КОФ - Колониальный Освободительный Фронт
+#define JOB_CLF_RU "КОФ Партизан"	// КОФ - Колониальный Освободительный Фронт
 #define JOB_CLF_ENGI_RU "КОФ Полевой Технарь"
 #define JOB_CLF_MEDIC_RU "КОФ Полевой Врач"
 #define JOB_CLF_SPECIALIST_RU "КОФ Полевой Специалист"


### PR DESCRIPTION
Правим перевод на Партизана, какой и должен быть

## Summary by Sourcery

Chores:
- Update Russian translation of "CLF Бугай" to "CLF Партизан".