### PR TITLE
[TM] Experimental: Decrease tank online cap to 140

### DIFF
--- a/code/game/jobs/job/command/auxiliary/tank_crew.dm
+++ b/code/game/jobs/job/command/auxiliary/tank_crew.dm
@@ -10,7 +10,7 @@
 	entry_message_body = "Your job is to operate and maintain the ship's armored vehicles. You are in charge of representing the armored presence amongst the marines during the operation, as well as maintaining and repairing your own vehicles."
 
 /datum/job/command/tank_crew/set_spawn_positions(count)
-	if (length(GLOB.clients) >= 200)
+	if (length(GLOB.clients) >= 140) // BANDAMARINES EDIT - 200 -> 140
 		spawn_positions = 2
 	else
 		spawn_positions = 0
@@ -18,7 +18,7 @@
 /datum/job/command/tank_crew/get_total_positions(latejoin = FALSE)
 	if(SStechtree.trees[TREE_MARINE].get_node(/datum/tech/arc).unlocked)
 		return 0
-	if(length(GLOB.clients) >= 200 || total_positions_so_far > 0)
+	if(length(GLOB.clients) >= 140 || total_positions_so_far > 0) // BANDAMARINES EDIT - 200 -> 140
 		return 2
 
 	return 0


### PR DESCRIPTION
Экспериментальное снижение онлайн капа танка с 200 до 140. Иначе мы никогда вне щитспавна танка, скорее всего, не увидим.
Если будет плохо, можно всегда будет откатить обратно.

## Summary by Sourcery

Decrease the online player count requirement for tank crew jobs from 200 to 140.