### PR TITLE
Fix categories when using coupon or selecting APC

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
+++ b/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
@@ -86,7 +86,7 @@
 	else if(selected_vehicle == "ARC")
 		display_list = GLOB.cm_vending_vehicle_crew_arc
 
-	else if(selected_vehicle == "TANK")
+	else if(selected_vehicle == "APC")
 		if(available_categories)
 			display_list = GLOB.cm_vending_vehicle_crew_apc
 		else //APC stuff costs more to prevent 4000 points spent on shitton of ammunition

--- a/code/modules/cm_tech/implements/tank.dm
+++ b/code/modules/cm_tech/implements/tank.dm
@@ -18,7 +18,7 @@
 	name = "tank coupon"
 	desc = "We're done playing! This coupon allows the ship crew to retrieve a complete Longstreet tank from Vehicle ASRS. Make sure to send the ASRS lift down so it can be retrieved. One use only. LTB not included. Comes with free friendly fire."
 	vehicle_type = /datum/vehicle_order/tank/broken
-	vehicle_category = "LONGSTREET"
+	vehicle_category = "TANK"
 
 /obj/item/vehicle_coupon/attack_self(mob/user)
 	if(QDELETED(src))


### PR DESCRIPTION
Исправляет говнокод оффов 👍, в результате которого не выдавались категории TANK и APC.

## Summary by Sourcery

Bug Fixes:
- Fixed a bug that prevented "TANK" category items from being displayed when using a coupon or selecting an APC in the vehicle crew vendor.