### PR TITLE
Barrel charger return

### DIFF
--- a/code/datums/supply_packs/attachments.dm
+++ b/code/datums/supply_packs/attachments.dm
@@ -84,6 +84,7 @@
 	containername = "extended barrel attachment crate"
 	group = "Attachments"
 
+// SS220 ADD Start - Return barrel charger
 /datum/supply_packs/muzzle_heavy
 	name = "barrel charger attachment crate (x2)"
 	contains = list(
@@ -94,6 +95,7 @@
 	containertype = /obj/structure/closet/crate
 	containername = "heavy barrel attachment crate"
 	group = "Attachments"
+// SS220 ADD End - Return barrel charger
 
 /datum/supply_packs/muzzle_compensator
 	name = "compensator attachment crate (x6)"

--- a/code/datums/supply_packs/attachments.dm
+++ b/code/datums/supply_packs/attachments.dm
@@ -84,7 +84,7 @@
 	containername = "extended barrel attachment crate"
 	group = "Attachments"
 
-// SS220 ADD Start - Return barrel charger
+// SS220 ADD Start - Barrel charger return
 /datum/supply_packs/muzzle_heavy
 	name = "barrel charger attachment crate (x2)"
 	contains = list(
@@ -95,7 +95,7 @@
 	containertype = /obj/structure/closet/crate
 	containername = "heavy barrel attachment crate"
 	group = "Attachments"
-// SS220 ADD End - Return barrel charger
+// SS220 ADD End - Barrel charger return
 
 /datum/supply_packs/muzzle_compensator
 	name = "compensator attachment crate (x6)"

--- a/code/datums/supply_packs/attachments.dm
+++ b/code/datums/supply_packs/attachments.dm
@@ -84,6 +84,17 @@
 	containername = "extended barrel attachment crate"
 	group = "Attachments"
 
+/datum/supply_packs/muzzle_heavy
+	name = "barrel charger attachment crate (x2)"
+	contains = list(
+		/obj/item/attachable/heavy_barrel,
+		/obj/item/attachable/heavy_barrel,
+	)
+	cost = 30
+	containertype = /obj/structure/closet/crate
+	containername = "heavy barrel attachment crate"
+	group = "Attachments"
+
 /datum/supply_packs/muzzle_compensator
 	name = "compensator attachment crate (x6)"
 	contains = list(

--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -393,6 +393,7 @@
 /obj/structure/machinery/cm_vending/sorted/attachments/populate_product_list(scale)
 	listed_products = list(
 		list("BARREL", -1, null, null),
+		list("Barrel Charger", 2.5, /obj/item/attachable/heavy_barrel, VENDOR_ITEM_REGULAR),
 		list("Extended Barrel", 6.5, /obj/item/attachable/extended_barrel, VENDOR_ITEM_REGULAR),
 		list("M5 Bayonet", 10.5, /obj/item/attachable/bayonet, VENDOR_ITEM_REGULAR),
 		list("Recoil Compensator", 6.5, /obj/item/attachable/compensator, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -393,7 +393,7 @@
 /obj/structure/machinery/cm_vending/sorted/attachments/populate_product_list(scale)
 	listed_products = list(
 		list("BARREL", -1, null, null),
-		list("Barrel Charger", 2.5, /obj/item/attachable/heavy_barrel, VENDOR_ITEM_REGULAR),
+		list("Barrel Charger", 2.5, /obj/item/attachable/heavy_barrel, VENDOR_ITEM_REGULAR), // SS220 ADD - Return barrel charger
 		list("Extended Barrel", 6.5, /obj/item/attachable/extended_barrel, VENDOR_ITEM_REGULAR),
 		list("M5 Bayonet", 10.5, /obj/item/attachable/bayonet, VENDOR_ITEM_REGULAR),
 		list("Recoil Compensator", 6.5, /obj/item/attachable/compensator, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -393,7 +393,7 @@
 /obj/structure/machinery/cm_vending/sorted/attachments/populate_product_list(scale)
 	listed_products = list(
 		list("BARREL", -1, null, null),
-		list("Barrel Charger", 2.5, /obj/item/attachable/heavy_barrel, VENDOR_ITEM_REGULAR), // SS220 ADD - Return barrel charger
+		list("Barrel Charger", 2.5, /obj/item/attachable/heavy_barrel, VENDOR_ITEM_REGULAR), // SS220 ADD - Barrel charger return
 		list("Extended Barrel", 6.5, /obj/item/attachable/extended_barrel, VENDOR_ITEM_REGULAR),
 		list("M5 Bayonet", 10.5, /obj/item/attachable/bayonet, VENDOR_ITEM_REGULAR),
 		list("Recoil Compensator", 6.5, /obj/item/attachable/compensator, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -367,7 +367,7 @@
 /obj/structure/machinery/cm_vending/sorted/attachments/squad/populate_product_list(scale)
 	listed_products = list(
 		list("BARREL", -1, null, null),
-		list("Barrel Charger", 0.9, /obj/item/attachable/heavy_barrel, VENDOR_ITEM_REGULAR), // SS220 ADD - Return barrel charger
+		list("Barrel Charger", 0.9, /obj/item/attachable/heavy_barrel, VENDOR_ITEM_REGULAR), // SS220 ADD - Barrel charger return
 		list("Extended Barrel", 2.5, /obj/item/attachable/extended_barrel, VENDOR_ITEM_REGULAR),
 		list("Recoil Compensator", 2.5, /obj/item/attachable/compensator, VENDOR_ITEM_REGULAR),
 		list("Suppressor", 2.5, /obj/item/attachable/suppressor, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -367,6 +367,7 @@
 /obj/structure/machinery/cm_vending/sorted/attachments/squad/populate_product_list(scale)
 	listed_products = list(
 		list("BARREL", -1, null, null),
+		list("Barrel Charger", 0.9, /obj/item/attachable/heavy_barrel, VENDOR_ITEM_REGULAR),
 		list("Extended Barrel", 2.5, /obj/item/attachable/extended_barrel, VENDOR_ITEM_REGULAR),
 		list("Recoil Compensator", 2.5, /obj/item/attachable/compensator, VENDOR_ITEM_REGULAR),
 		list("Suppressor", 2.5, /obj/item/attachable/suppressor, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -367,7 +367,7 @@
 /obj/structure/machinery/cm_vending/sorted/attachments/squad/populate_product_list(scale)
 	listed_products = list(
 		list("BARREL", -1, null, null),
-		list("Barrel Charger", 0.9, /obj/item/attachable/heavy_barrel, VENDOR_ITEM_REGULAR),
+		list("Barrel Charger", 0.9, /obj/item/attachable/heavy_barrel, VENDOR_ITEM_REGULAR), // SS220 ADD - Return barrel charger
 		list("Extended Barrel", 2.5, /obj/item/attachable/extended_barrel, VENDOR_ITEM_REGULAR),
 		list("Recoil Compensator", 2.5, /obj/item/attachable/compensator, VENDOR_ITEM_REGULAR),
 		list("Suppressor", 2.5, /obj/item/attachable/suppressor, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION
# About the pull request
Возвращает barrel charger в вендоры обвесов карго и отрядов.

# Explain why it's good for the game
В своё время были абузы с этим надульником, но их уже пофиксили, а надульник так и не вернули в ротацию маринам. 