### PR TITLE
Add cyrillic support to modpacks list

### DIFF
--- a/modular/_modpacks.dm
+++ b/modular/_modpacks.dm
@@ -41,7 +41,7 @@ SUBSYSTEM_DEF(modpacks)
 		return
 
 	if(length(SSmodpacks.loaded_modpacks))
-		. = "<hr><br><center><b><font size = 3>Список модификаций</font></b></center><br><hr><br>"
+		. = "<meta charset='UTF-8'><hr><br><center><b><font size = 3>Список модификаций</font></b></center><br><hr><br>"
 		for(var/datum/modpack/M as anything in SSmodpacks.loaded_modpacks)
 			if(M.name)
 				. += "<div class = 'statusDisplay'>"


### PR DESCRIPTION
# About the pull request
Добавляет поддержку кириллицы в лист модпаков.

# Explain why it's good for the game
Читабельный лист модпаков.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>
До фикса:

![image](https://github.com/user-attachments/assets/d608a804-f75e-4334-a914-c0893a343b99)

После фикса:

![image](https://github.com/user-attachments/assets/6d45089f-d852-4166-b685-90e78bb9d5b7)

</details>

## Summary by Sourcery

Исправления ошибок:
- Исправлено отображение кириллических символов в списке модпаков, которые ранее отображались искаженными или нечитаемыми из-за отсутствия метаданных кодировки символов. Это гарантирует, что названия модпаков с кириллическими символами будут правильно отображаться для пользователей.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixed the display of Cyrillic characters in the modpack list, which previously appeared garbled or unreadable due to missing character encoding metadata. This ensures that modpack names with Cyrillic characters are displayed correctly to users.

</details>