### PR TITLE
Modpacks list tgui

### DIFF
--- a/tgui/packages/tgui/interfaces/ModpacksList.jsx
+++ b/tgui/packages/tgui/interfaces/ModpacksList.jsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+
+import { useBackend } from '../backend';
+import { Collapsible, Input, Section, Stack } from '../components';
+import { Window } from '../layouts';
+
+export const ModpacksList = (props, context) => {
+  return (
+    <Window width={500} height={550}>
+      <Window.Content>
+        <Stack fill vertical>
+          <ModpacksListContent />
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};
+
+export const ModpacksListContent = (props, context) => {
+  const { act, data } = useBackend();
+  const { modpacks } = data;
+
+  const [searchText, setSearchText] = useState('');
+
+  const searchBar = (
+    <Input
+      placeholder="Искать модпак по имени, описанию или автору..."
+      fluid
+      onInput={(e, value) => setSearchText(value)}
+    />
+  );
+
+  return (
+    <>
+      <Stack.Item>
+        <Section fill title="Фильтры">
+          {searchBar}
+        </Section>
+      </Stack.Item>
+      <Stack.Item grow>
+        <Section
+          fill
+          scrollable
+          title={
+            searchText.length > 0
+              ? `Результаты поиска "${searchText}"`
+              : `Все модификации - ${modpacks.length}`
+          }
+        >
+          <Stack fill vertical>
+            <Stack.Item>
+              {modpacks
+                .filter(
+                  (modpack) =>
+                    modpack.name &&
+                    (searchText.length > 0
+                      ? modpack.name
+                          .toLowerCase()
+                          .includes(searchText.toLowerCase()) ||
+                        modpack.desc
+                          .toLowerCase()
+                          .includes(searchText.toLowerCase()) ||
+                        modpack.author
+                          .toLowerCase()
+                          .includes(searchText.toLowerCase())
+                      : true),
+                )
+                .map((modpack) => (
+                  <Collapsible key={modpack.name} title={modpack.name}>
+                    <Section title="Описание">{modpack.desc}</Section>
+                    <Section title="Авторы">{modpack.author}</Section>
+                  </Collapsible>
+                ))}
+            </Stack.Item>
+          </Stack>
+        </Section>
+      </Stack.Item>
+    </>
+  );
+};

--- a/tgui/packages/tgui/interfaces/ModpacksList.tsx
+++ b/tgui/packages/tgui/interfaces/ModpacksList.tsx
@@ -16,8 +16,18 @@ export const ModpacksList = (props, context) => {
   );
 };
 
+type ModpacksData = {
+  modpacks: Modpack[];
+};
+
+type Modpack = {
+  name: string;
+  desc: string;
+  author: string;
+};
+
 export const ModpacksListContent = (props, context) => {
-  const { act, data } = useBackend();
+  const { act, data } = useBackend<ModpacksData>();
   const { modpacks } = data;
 
   const [searchText, setSearchText] = useState('');


### PR DESCRIPTION
# About the pull request
Портирует ТГУИ для списка модпаков с парадиза.

# Explain why it's good for the game
Красивая менюшка вместо бйондовского окна.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

https://github.com/user-attachments/assets/d4d5b06c-d357-4a73-862d-e8132d49317a

</details>

## Summary by Sourcery

Этот пул-реквест представляет новый интерфейс на основе TGUI для отображения списка модпаков. Он заменяет старое окно BYOND на более современный и удобный интерфейс, включающий поиск и сворачиваемые разделы для каждого модпака.

Новые возможности:
- Реализован интерфейс TGUI для списка модпаков, заменяющий предыдущее окно BYOND на более современный и удобный интерфейс.

Улучшения:
- Новый интерфейс TGUI включает в себя строку поиска для фильтрации модпаков по имени, описанию или автору.
- Модпаки отображаются в виде сворачиваемого списка, показывающего описание и автора при развертывании.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This pull request introduces a new TGUI-based interface for displaying the list of modpacks. It replaces the old BYOND window with a more modern and user-friendly interface, including search and collapsible sections for each modpack.

New Features:
- Implements a TGUI interface for the modpacks list, replacing the previous BYOND window with a more modern and user-friendly interface.

Enhancements:
- The new TGUI interface includes a search bar to filter modpacks by name, description, or author.
- The modpacks are displayed in a collapsible list, showing the description and author when expanded.

</details>