### PR TITLE
Round Stats Viewer

### DIFF
--- a/modular/modular.dme
+++ b/modular/modular.dme
@@ -11,6 +11,7 @@
 #include "respawn/_respawn.dme"
 #include "sounds/_sounds.dme"
 #include "translations/_translations.dme"
+#include "stats_viewer/_stats_viewer.dme"
 #include "speech_filter/_speech_filter.dme"
 #include "text_to_speech/_tts.dme"
 #include "attachments/_attachments.dme"

--- a/modular/stats_viewer/_stats_viewer.dm
+++ b/modular/stats_viewer/_stats_viewer.dm
@@ -1,16 +1,4 @@
-/datum/modpack/example
-	/// A string name for the modpack. Used for looking up other modpacks in init.
-	name = "Example modpack"
-	/// A string desc for the modpack. Can be used for modpack verb list as description.
-	desc = "its useless"
-	/// A string with authors of this modpack.
-	author = "furior, phantomru"
-
-/datum/modpack/example/pre_initialize()
-	. = ..()
-
-/datum/modpack/example/initialize()
-	. = ..()
-
-/datum/modpack/example/post_initialize()
-	. = ..()
+/datum/modpack/round_stats
+	name = "Round Stats Viewer"
+	desc = "Добавляет кнопку OOC -> View My Stats, в которой можно посмотреть статистику за раунд."
+	author = "larentoun"

--- a/modular/stats_viewer/_stats_viewer.dm
+++ b/modular/stats_viewer/_stats_viewer.dm
@@ -1,0 +1,16 @@
+/datum/modpack/example
+	/// A string name for the modpack. Used for looking up other modpacks in init.
+	name = "Example modpack"
+	/// A string desc for the modpack. Can be used for modpack verb list as description.
+	desc = "its useless"
+	/// A string with authors of this modpack.
+	author = "furior, phantomru"
+
+/datum/modpack/example/pre_initialize()
+	. = ..()
+
+/datum/modpack/example/initialize()
+	. = ..()
+
+/datum/modpack/example/post_initialize()
+	. = ..()

--- a/modular/stats_viewer/_stats_viewer.dme
+++ b/modular/stats_viewer/_stats_viewer.dme
@@ -1,0 +1,3 @@
+#include "_stats_viewer.dm"
+
+#include "code/stats_viewer.dm"

--- a/modular/stats_viewer/code/stats_viewer.dm
+++ b/modular/stats_viewer/code/stats_viewer.dm
@@ -1,0 +1,67 @@
+/mob/proc/view_round_stats()
+	set name = "View My Stats"
+	set category = "OOC"
+
+	_view_round_stats()
+
+/mob/proc/_view_round_stats()
+	var/list/datum/entity/statistic/death/death_list = list()
+	// Find all our deaths
+	if(length(GLOB.round_statistics.death_stats_list))
+		var/datum/entity/player/player = get_player_from_key("[ckey]")
+		for(var/datum/entity/statistic/death/death in GLOB.round_statistics.death_stats_list)
+			if(death.player_id != player.id)
+				continue
+			death_list += death
+
+	var/list/data = list()
+	if(length(death_list))
+		for(var/datum/entity/statistic/death/death in death_list)
+			data["[death.mob_name]"] = death.get_round_stats(data["[death.mob_name]"])
+
+		to_chat(src, "Your death stats are:")
+		for(var/key in data)
+			to_chat(src, "Character: [key]")
+			to_chat(src, "Total steps: [data[key]["total_steps"]]")
+			to_chat(src, "Total kills: [data[key]["total_kills"]]")
+			to_chat(src, "Total time alive: [data[key]["total_time_alive"]]")
+			to_chat(src, "Total damage taken: [data[key]["total_damage_taken"]]")
+			to_chat(src, "Total revives done: [data[key]["total_revives_done"]]")
+			to_chat(src, "Total ib fixed: [data[key]["total_ib_fixed"]]")
+
+	get_living_round_stats()
+
+/datum/entity/statistic/death/proc/get_round_stats(list/append_data = list())
+	var/list/data = list()
+	data["total_steps"] = total_steps + append_data["total_steps"]
+	data["total_kills"] = total_kills + append_data["total_kills"]
+	data["total_time_alive"] = total_time_alive + append_data["total_time_alive"]
+	data["total_damage_taken"] = total_damage_taken + append_data["total_damage_taken"]
+	data["total_revives_done"] = total_revives_done + append_data["total_revives_done"]
+	data["total_ib_fixed"] = total_ib_fixed + append_data["total_ib_fixed"]
+	return data
+
+/mob/proc/get_living_round_stats()
+	return
+
+/mob/living/carbon/human/get_living_round_stats()
+	to_chat(src, "Your living stats are:")
+	to_chat(src, "Character: [real_name]")
+	to_chat(src, "Total steps: [life_steps_total]")
+	to_chat(src, "Total kills: [life_kills_total]")
+	to_chat(src, "Total time alive: [world.time - life_time_start]")
+	to_chat(src, "Total damage taken: [life_damage_taken_total]")
+	to_chat(src, "Total revives done: [life_revives_total]")
+	to_chat(src, "Total ib fixed: [life_ib_total]")
+
+/mob/living/carbon/xenomorph/get_living_round_stats()
+	to_chat(src, "Your living stats are:")
+	to_chat(src, "Character: [real_name]")
+	to_chat(src, "Total steps: [life_steps_total]")
+	to_chat(src, "Total kills: [life_kills_total]")
+	to_chat(src, "Total time alive: [world.time - life_time_start]")
+	to_chat(src, "Total damage taken: [life_damage_taken_total]")
+	to_chat(src, "Total revives done: [life_revives_total]")
+	to_chat(src, "Total ib fixed: [life_ib_total]")
+
+// show_end_statistics

--- a/modular/stats_viewer/code/stats_viewer.dm
+++ b/modular/stats_viewer/code/stats_viewer.dm
@@ -4,6 +4,9 @@
 
 	if(!client)
 		return
+	if(stat != DEAD && SSticker.current_state != GAME_STATE_FINISHED)
+		to_chat(src, SPAN_WARNING("Вы можете посмотреть статистику только будучи мертвым, или когда раунд закончился!"))
+		return
 	var/datum/round_stats/round_stats = new()
 	round_stats.tgui_interact(src)
 

--- a/tgui/packages/tgui/interfaces/ModpacksList.tsx
+++ b/tgui/packages/tgui/interfaces/ModpacksList.tsx
@@ -26,7 +26,7 @@ type Modpack = {
   author: string;
 };
 
-export const ModpacksListContent = (props, context) => {
+const ModpacksListContent = (props, context) => {
   const { act, data } = useBackend<ModpacksData>();
   const { modpacks } = data;
 

--- a/tgui/packages/tgui/interfaces/RoundStats.tsx
+++ b/tgui/packages/tgui/interfaces/RoundStats.tsx
@@ -1,0 +1,109 @@
+import { useBackend } from '../backend';
+import { Collapsible, LabeledList, Section, Stack } from '../components';
+import { Window } from '../layouts';
+
+export const RoundStats = (props) => {
+  return (
+    <Window width={500} height={550}>
+      <Window.Content>
+        <Stack fill vertical>
+          <RoundStatsContent />
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};
+
+type StatsData = {
+  stats: Stats[];
+};
+
+type Stats = {
+  title: string;
+  total_kills: number;
+  total_deaths: number;
+  steps_walked: number;
+  humans_killed: number;
+  xenos_killed: number;
+  total_friendly_fire: number;
+  total_revives: number;
+  total_lives_saved: number;
+  total_shots: number;
+  total_shots_hit: number;
+  total_hits: number;
+};
+
+export const RoundStatsContent = (props, context) => {
+  const { data } = useBackend<StatsData>();
+  const { stats } = data;
+
+  return (
+    <Section fill scrollable title={`Ваша статистика за раунд`}>
+      <Stack fill vertical>
+        <Stack.Item grow>
+          {stats.map((stat) => (
+            <Collapsible key={stat.title} title={stat.title}>
+              <LabeledList>
+                {stat.steps_walked ? (
+                  <LabeledList.Item label="Шагов сделано">
+                    {stat.steps_walked}
+                  </LabeledList.Item>
+                ) : null}
+                {stat.total_kills ? (
+                  <LabeledList.Item label="Всего убито">
+                    {stat.total_kills}
+                  </LabeledList.Item>
+                ) : null}
+                {stat.humans_killed ? (
+                  <LabeledList.Item label="Убито людей">
+                    {stat.humans_killed}
+                  </LabeledList.Item>
+                ) : null}
+                {stat.xenos_killed ? (
+                  <LabeledList.Item label="Убито ксеноморфов">
+                    {stat.xenos_killed}
+                  </LabeledList.Item>
+                ) : null}
+                {stat.total_shots ? (
+                  <LabeledList.Item label="Выстрелов сделано">
+                    {stat.total_shots}
+                  </LabeledList.Item>
+                ) : null}
+                {stat.total_shots ? (
+                  <LabeledList.Item label="Точность">
+                    {Math.round(stat.total_shots_hit / stat.total_shots) + `%`}
+                  </LabeledList.Item>
+                ) : null}
+                {stat.total_friendly_fire ? (
+                  <LabeledList.Item label="Попаданий по своим">
+                    {stat.total_friendly_fire}
+                  </LabeledList.Item>
+                ) : null}
+                {stat.total_deaths ? (
+                  <LabeledList.Item label="Количество смертей">
+                    {stat.total_deaths}
+                  </LabeledList.Item>
+                ) : null}
+                {stat.total_revives ? (
+                  <LabeledList.Item label="Количество воскрешений">
+                    {stat.total_revives}
+                  </LabeledList.Item>
+                ) : null}
+                {stat.total_lives_saved ? (
+                  <LabeledList.Item label="Людей реанимировано">
+                    {stat.total_lives_saved}
+                  </LabeledList.Item>
+                ) : null}
+                {stat.total_hits ? (
+                  <LabeledList.Item label="Попаданий когтями">
+                    {stat.total_hits}
+                  </LabeledList.Item>
+                ) : null}
+              </LabeledList>
+            </Collapsible>
+          ))}
+        </Stack.Item>
+      </Stack>
+    </Section>
+  );
+};

--- a/tgui/packages/tgui/interfaces/RoundStats.tsx
+++ b/tgui/packages/tgui/interfaces/RoundStats.tsx
@@ -71,7 +71,9 @@ export const RoundStatsContent = (props, context) => {
                 ) : null}
                 {stat.total_shots ? (
                   <LabeledList.Item label="Точность">
-                    {Math.round(stat.total_shots_hit / stat.total_shots) + `%`}
+                    {Math.round(
+                      (stat.total_shots_hit / stat.total_shots) * 100,
+                    ) + `%`}
                   </LabeledList.Item>
                 ) : null}
                 {stat.total_friendly_fire ? (

--- a/tgui/packages/tgui/interfaces/RoundStats.tsx
+++ b/tgui/packages/tgui/interfaces/RoundStats.tsx
@@ -44,63 +44,63 @@ export const RoundStatsContent = (props, context) => {
           {stats.map((stat) => (
             <Collapsible key={stat.title} title={stat.title}>
               <LabeledList>
-                {stat.steps_walked ? (
+                {!!stat.steps_walked && (
                   <LabeledList.Item label="Шагов сделано">
                     {stat.steps_walked}
                   </LabeledList.Item>
-                ) : null}
-                {stat.total_kills ? (
+                )}
+                {!!stat.total_kills && (
                   <LabeledList.Item label="Всего убито">
                     {stat.total_kills}
                   </LabeledList.Item>
-                ) : null}
-                {stat.humans_killed ? (
+                )}
+                {!!stat.humans_killed && (
                   <LabeledList.Item label="Убито людей">
                     {stat.humans_killed}
                   </LabeledList.Item>
-                ) : null}
-                {stat.xenos_killed ? (
+                )}
+                {!!stat.xenos_killed && (
                   <LabeledList.Item label="Убито ксеноморфов">
                     {stat.xenos_killed}
                   </LabeledList.Item>
-                ) : null}
-                {stat.total_shots ? (
+                )}
+                {!!stat.total_shots && (
                   <LabeledList.Item label="Выстрелов сделано">
                     {stat.total_shots}
                   </LabeledList.Item>
-                ) : null}
-                {stat.total_shots ? (
+                )}
+                {!!stat.total_shots && (
                   <LabeledList.Item label="Точность">
                     {Math.round(
                       (stat.total_shots_hit / stat.total_shots) * 100,
                     ) + `%`}
                   </LabeledList.Item>
-                ) : null}
-                {stat.total_friendly_fire ? (
+                )}
+                {!!stat.total_friendly_fire && (
                   <LabeledList.Item label="Попаданий по своим">
                     {stat.total_friendly_fire}
                   </LabeledList.Item>
-                ) : null}
-                {stat.total_deaths ? (
+                )}
+                {!!stat.total_deaths && (
                   <LabeledList.Item label="Количество смертей">
                     {stat.total_deaths}
                   </LabeledList.Item>
-                ) : null}
-                {stat.total_revives ? (
+                )}
+                {!!stat.total_revives && (
                   <LabeledList.Item label="Количество воскрешений">
                     {stat.total_revives}
                   </LabeledList.Item>
-                ) : null}
-                {stat.total_lives_saved ? (
+                )}
+                {!!stat.total_lives_saved && (
                   <LabeledList.Item label="Людей реанимировано">
                     {stat.total_lives_saved}
                   </LabeledList.Item>
-                ) : null}
-                {stat.total_hits ? (
+                )}
+                {!!stat.total_hits && (
                   <LabeledList.Item label="Попаданий когтями">
                     {stat.total_hits}
                   </LabeledList.Item>
-                ) : null}
+                )}
               </LabeledList>
             </Collapsible>
           ))}


### PR DESCRIPTION
## Что этот PR делает
Начало работы над системой, тут можно МНОГО сделать чето интересного. Пока вставлена база, которая видна в "медальках" - количество убийств, попадания, процент точности.

![image](https://github.com/user-attachments/assets/281b53c9-48ee-4b6e-9d8f-feb1724c095a)
![image](https://github.com/user-attachments/assets/d377489a-d28d-4707-88b6-981e74ac101b)


## В будущем сделаем
Статистику за каждое оружие
Статистику за каждую касту (абилки использованные, попадания)
Статистику за каждую профу (типо сначала за рифлмена, потом за фокстрот)

## Changelog

:cl:
add: Добавлена кнопка OOC -> "View My Stats", которая позволяет посмотреть вашу статистику за раунд.
/:cl:
