### PR TITLE
Remove TTS from Working Joe

### DIFF
--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -795,6 +795,8 @@
 	new_human.g_facial = 255
 	new_human.b_facial = 255
 
+	new_human.remove_tts_component() // BANDAMARINES ADD
+
 /datum/equipment_preset/synth/working_joe/load_vanity(mob/living/carbon/human/new_human)
 	return
 

--- a/modular/text_to_speech/code/base_seeds/mobs/_base.dm
+++ b/modular/text_to_speech/code/base_seeds/mobs/_base.dm
@@ -9,6 +9,11 @@
 /mob/living/silicon/add_tts_component()
 	AddComponent(/datum/component/tts_component, null, TTS_TRAIT_ROBOTIZE)
 
+/mob/living/remove_tts_component()
+	var/datum/component/tts_component/tts_component = GetComponent(/datum/component/tts_component)
+	if(tts_component)
+		tts_component.RemoveComponent()
+
 /mob/living/carbon/Initialize()
 	. = ..()
 	tts_seed = get_tts_seed()

--- a/modular/text_to_speech/code/tts_atom.dm
+++ b/modular/text_to_speech/code/tts_atom.dm
@@ -1,6 +1,9 @@
 /atom/proc/add_tts_component()
 	return
 
+/atom/proc/remove_tts_component()
+	return
+
 /atom/Initialize(mapload, ...)
 	. = ..()
 	add_tts_component()


### PR DESCRIPTION
## Что этот PR делает
Убирает ТТС компонент у Рабочего Джо, так так у него есть своя озвучка фраз
## Тестирование
Локальные тесты
## Changelog

:cl:
del: Удален ТТС у Рабочего Джо
/:cl:

## Обзор от Sourcery

Улучшения:
- Удаляет TTS компонент из киборга Working Joe, так как у него есть свои собственные голосовые реплики.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Removes the TTS component from the Working Joe cyborg, as it has its own voice lines.

</details>