### PR TITLE
Runechat LOOC for everyone

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -174,7 +174,7 @@
 
 	if(mob.looc_overhead || GLOB.ooc_allowed)
 		var/transmit_language = isxeno(mob) ? LANGUAGE_XENOMORPH : LANGUAGE_ENGLISH
-		mob.langchat_speech(msg, heard, GLOB.all_languages[transmit_language], "#ff47d7")
+		mob.langchat_speech("LOOC: [msg]", heard, GLOB.all_languages[transmit_language], "#ff47d7") // BANDAMARINES EDIT
 
 	// Now handle admins
 	display_name = S.key

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -170,11 +170,11 @@
 			continue //they are handled after that
 
 		if(C.prefs.toggles_chat & CHAT_LOOC)
-			to_chat(C, "<font color='#f557b8'><span class='ooc linkify'><span class='prefix'>LOOC:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>")
+			to_chat(C, "<font color='#6699cc'><span class='ooc linkify'><span class='prefix'>LOOC:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>") // BANDAMARINES EDIT color #f557b8->#6699cc
 
 	if(mob.looc_overhead || GLOB.ooc_allowed)
 		var/transmit_language = isxeno(mob) ? LANGUAGE_XENOMORPH : LANGUAGE_ENGLISH
-		mob.langchat_speech("LOOC: [msg]", heard, GLOB.all_languages[transmit_language], "#ff47d7") // BANDAMARINES EDIT
+		mob.langchat_speech("LOOC: [msg]", heard, GLOB.all_languages[transmit_language], "#6699cc") // BANDAMARINES EDIT add LOOC: and color #f557b8->#6699cc
 
 	// Now handle admins
 	display_name = S.key
@@ -189,7 +189,7 @@
 			var/prefix = "(R)LOOC"
 			if (C.mob in heard)
 				prefix = "LOOC"
-			to_chat(C, "<font color='#f557b8'><span class='ooc linkify'><span class='prefix'>[prefix]:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>")
+			to_chat(C, "<font color='#6699cc'><span class='ooc linkify'><span class='prefix'>[prefix]:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>") // BANDAMARINES EDIT color #f557b8->#6699cc
 
 /client/verb/round_info()
 	set name = "Current Map" //Gave this shit a shorter name so you only have to time out "ooc" rather than "ooc message" to use it --NeoFite

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -161,7 +161,7 @@
 	var/faction = FACTION_NEUTRAL
 	var/faction_group
 
-	var/looc_overhead = FALSE
+	var/looc_overhead = TRUE // BANDAMARINES EDIT FALSE->TRUE
 
 	var/datum/skills/skills = null //the knowledge you have about certain abilities and actions (e.g. do you how to do surgery?)
 									//see skills.dm in #define folder and code/datums/skills.dm for more info

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -1585,3 +1585,8 @@ em {
   margin: 0;
   padding: 0;
 }
+
+// BANDAMARINES ADDITION START
+.looc {
+  color: #6699cc;
+}

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -1578,3 +1578,8 @@ h2.alert {
   margin: 0;
   padding: 0;
 }
+
+// BANDAMARINES ADDITION START
+.looc {
+  color: #6699cc;
+}

--- a/tgui/packages/tgui-say/styles/colors.scss
+++ b/tgui/packages/tgui-say/styles/colors.scss
@@ -18,6 +18,8 @@ $looc: #e362b4;
 $mentor: #b5850d;
 $asay: #74471b;
 
+$looc: #6699cc; // BANDAMARINES ADDITION
+
 ////////////////////////////////////////////////
 // Subchannel chat colors
 $highcom: #318779;


### PR DESCRIPTION
## Что этот PR делает
Включает рунчат для LOOC всем
Меняет цвет LOOC на #6699cc
Closes #156 
## Почему это хорошо для игры
Проще заметить подсказки
## Изображения изменений
![image](https://github.com/user-attachments/assets/03bf5f50-cd73-4bd3-9483-0accec4bc498)
## Тестирование
Локальные тесты
## Changelog

:cl:
add: Всем включен рунчат для LOOC
/:cl:

## Обзор от Sourcery

Улучшения:
- Включен LOOC (Local Out of Character) чат для всех игроков, что упрощает обнаружение подсказок и координацию.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Enabled LOOC (Local Out of Character) chat for all players, making it easier to notice hints and coordinate.

</details>