### PR TITLE
[TM] Bump Attacks moved to config, slight nerf

### DIFF
--- a/code/datums/statistics/entities/panel_stats.dm
+++ b/code/datums/statistics/entities/panel_stats.dm
@@ -750,5 +750,6 @@
 		"death_stats_list" = new_death_stats_list,
 		"weapon_stats_list" = new_weapon_stats_list,
 		"job_stats_list" = new_job_stats_list,
-		"caste_stats_list" = new_caste_stats_list
+		"caste_stats_list" = new_caste_stats_list,
+		"xeno_bump_attacks" = xeno_bump_attacks, // BANDAMARINES EDIT - Bump Attacks
 	)

--- a/code/datums/statistics/entities/round_stats.dm
+++ b/code/datums/statistics/entities/round_stats.dm
@@ -88,7 +88,8 @@
 		"total_projectiles_hit_human" = DB_FIELDTYPE_INT,
 		"total_projectiles_hit_xeno" = DB_FIELDTYPE_INT,
 		"total_friendly_fire_instances" = DB_FIELDTYPE_INT,
-		"total_slashes" = DB_FIELDTYPE_INT
+		"total_slashes" = DB_FIELDTYPE_INT,
+		"xeno_bump_attacks" = DB_FIELDTYPE_INT, // BANDAMARINES EDIT - Bump Attacks
 	)
 
 /datum/game_mode/proc/setup_round_stats()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -75,6 +75,7 @@ GLOBAL_LIST_INIT(admin_verbs_default, list(
 	/client/proc/add_known_alt,
 	/client/proc/remove_known_alt,
 	/client/proc/toogle_door_control,
+	/datum/admins/proc/toggle_bump_attacks, // BANDAMARINES EDIT ADD - Bump Attacks
 	))
 
 GLOBAL_LIST_INIT(admin_verbs_admin, list(

--- a/config/example/bandamarines_config.txt
+++ b/config/example/bandamarines_config.txt
@@ -6,3 +6,6 @@
 
 ## Enables diagonal movement
 # DIAGONAL_MOVE
+
+## Enables Bump Attacks
+# BUMP_ATTACKS

--- a/modular/bump_attacks/_bump_attacks.dm
+++ b/modular/bump_attacks/_bump_attacks.dm
@@ -3,6 +3,6 @@
 	desc = "Adds bump attacks from TGMC"
 	author = "TGMC, larentoun"
 
-/datum/modpack/bump_attacks/post_initialize()
+/datum/modpack/bump_attacks/pre_initialize()
 	. = ..()
 	GLOB.admin_verbs_default += /datum/admins/proc/toggle_bump_attacks

--- a/modular/bump_attacks/_bump_attacks.dm
+++ b/modular/bump_attacks/_bump_attacks.dm
@@ -2,7 +2,3 @@
 	name = "Bump Attacks"
 	desc = "Adds bump attacks from TGMC"
 	author = "TGMC, larentoun"
-
-/datum/modpack/bump_attacks/pre_initialize()
-	. = ..()
-	GLOB.admin_verbs_default += /datum/admins/proc/toggle_bump_attacks

--- a/modular/bump_attacks/_bump_attacks.dm
+++ b/modular/bump_attacks/_bump_attacks.dm
@@ -2,3 +2,7 @@
 	name = "Bump Attacks"
 	desc = "Adds bump attacks from TGMC"
 	author = "TGMC, larentoun"
+
+/datum/modpack/bump_attacks/post_initialize()
+	. = ..()
+	GLOB.admin_verbs_default += /datum/admins/proc/toggle_bump_attacks

--- a/modular/bump_attacks/_bump_attacks.dme
+++ b/modular/bump_attacks/_bump_attacks.dme
@@ -3,3 +3,5 @@
 #include "code/bump_attacks_atoms.dm"
 #include "code/bump_attacks_button.dm"
 #include "code/bump_attacks_component.dm"
+#include "code/bump_attacks_config.dm"
+#include "code/bump_attacks_mob.dm"

--- a/modular/bump_attacks/_bump_attacks.dme
+++ b/modular/bump_attacks/_bump_attacks.dme
@@ -5,3 +5,4 @@
 #include "code/bump_attacks_component.dm"
 #include "code/bump_attacks_config.dm"
 #include "code/bump_attacks_mob.dm"
+#include "code/bump_attacks_statistics.dm"

--- a/modular/bump_attacks/code/bump_attacks_component.dm
+++ b/modular/bump_attacks/code/bump_attacks_component.dm
@@ -154,7 +154,3 @@
 	// SSblackbox.record_feedback("tally", "round_statistics", 1, "xeno_bump_attacks")
 	// TIMER_COOLDOWN_START(src, COOLDOWN_BUMP_ATTACK, bumper.xeno_caste.attack_delay)
 	return COMPONENT_LIVING_COLLIDE_HANDLED
-
-/mob/living/carbon/xenomorph/add_abilities()
-	AddComponent(/datum/component/bump_attack)
-	. = ..()

--- a/modular/bump_attacks/code/bump_attacks_component.dm
+++ b/modular/bump_attacks/code/bump_attacks_component.dm
@@ -62,6 +62,8 @@
 	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_BUMP_ATTACK))
 		return NONE
 	var/mob/living/bumper = parent
+	if(bumper.a_intent != INTENT_HARM)
+		return
 	if(!(target.flags_atom & BUMP_ATTACKABLE) || bumper.throwing || bumper.is_mob_incapacitated())
 		return NONE
 

--- a/modular/bump_attacks/code/bump_attacks_component.dm
+++ b/modular/bump_attacks/code/bump_attacks_component.dm
@@ -6,7 +6,7 @@
 	///Action used to turn bump attack on/off manually
 	var/datum/action/xeno_action/bump_attack_toggle/toggle_action
 	var/toggle_action_path = /datum/action/xeno_action/bump_attack_toggle
-	var/movement_delay_on_bump = 0.2 SECONDS
+	var/movement_delay_on_bump = 0.5 SECONDS
 
 /datum/component/bump_attack/Initialize(enabled = TRUE, has_button = TRUE, silent_activation = FALSE)
 	. = ..()

--- a/modular/bump_attacks/code/bump_attacks_component.dm
+++ b/modular/bump_attacks/code/bump_attacks_component.dm
@@ -6,6 +6,7 @@
 	///Action used to turn bump attack on/off manually
 	var/datum/action/xeno_action/bump_attack_toggle/toggle_action
 	var/toggle_action_path = /datum/action/xeno_action/bump_attack_toggle
+	var/movement_delay_on_bump = 0.2 SECONDS
 
 /datum/component/bump_attack/Initialize(enabled = TRUE, has_button = TRUE, silent_activation = FALSE)
 	. = ..()
@@ -63,7 +64,7 @@
 		return NONE
 	var/mob/living/bumper = parent
 	if(bumper.a_intent != INTENT_HARM)
-		return
+		return NONE
 	if(!(target.flags_atom & BUMP_ATTACKABLE) || bumper.throwing || bumper.is_mob_incapacitated())
 		return NONE
 
@@ -152,7 +153,8 @@
 	if(bumper.next_move > world.time)
 		return COMPONENT_LIVING_COLLIDE_HANDLED //We don't want to push people while on attack cooldown.
 	bumper.UnarmedAttack(target, TRUE)
-	// GLOB.round_statistics.xeno_bump_attacks++
+	bumper.client?.next_movement += movement_delay_on_bump
+	GLOB.round_statistics.xeno_bump_attacks++
 	// SSblackbox.record_feedback("tally", "round_statistics", 1, "xeno_bump_attacks")
 	// TIMER_COOLDOWN_START(src, COOLDOWN_BUMP_ATTACK, bumper.xeno_caste.attack_delay)
 	return COMPONENT_LIVING_COLLIDE_HANDLED

--- a/modular/bump_attacks/code/bump_attacks_config.dm
+++ b/modular/bump_attacks/code/bump_attacks_config.dm
@@ -9,7 +9,7 @@
 		return
 
 	var/confirm = tgui_alert(usr, "Вы уверены, что хотите [CONFIG_GET(flag/bump_attacks) ? "выключить" : "включить"] Bump Attacks?", "Toggle Bump Attacks", list("Да", "Нет"))
-	if(confirm == "Нет")
+	if(confirm != "Да")
 		return
 
 	CONFIG_SET(flag/bump_attacks, !CONFIG_GET(flag/bump_attacks))

--- a/modular/bump_attacks/code/bump_attacks_config.dm
+++ b/modular/bump_attacks/code/bump_attacks_config.dm
@@ -1,0 +1,23 @@
+/datum/config_entry/flag/bump_attacks
+	default = FALSE
+
+/datum/admins/proc/toggle_bump_attacks()
+	set name = "Toggle Bump Attacks"
+	set desc = "Enables/Disables Bump Attacks"
+	set category = "Admin"
+	if(!(usr.client.admin_holder?.rights & R_ADMIN))
+		return
+
+	var/confirm = tgui_alert(usr, "Вы уверены, что хотите [CONFIG_GET(flag/bump_attacks) ? "выключить" : "включить"] Bump Attacks?", "Toggle Bump Attacks", list("Да", "Нет"))
+	if(confirm == "Нет")
+		return
+
+	CONFIG_SET(flag/bump_attacks, !CONFIG_GET(flag/bump_attacks))
+	for(var/mob/player in GLOB.player_list)
+		if(CONFIG_GET(flag/bump_attacks))
+			player.add_bump_attacks()
+		else
+			player.remove_bump_attacks()
+
+	to_world(SPAN_NOTICE("На сервере теперь [CONFIG_GET(flag/bump_attacks) ? "включены" : "выключены"] Bump Attacks!"))
+	log_admin("[key_name(usr)] переключил Bump Attacks. Новое значение - [CONFIG_GET(flag/bump_attacks)]")

--- a/modular/bump_attacks/code/bump_attacks_mob.dm
+++ b/modular/bump_attacks/code/bump_attacks_mob.dm
@@ -1,0 +1,15 @@
+/mob/proc/remove_bump_attacks()
+	var/datum/component/bump_attacks/component = player.GetComponent(/datum/component/bump_attack)
+	if(component)
+		qdel(component)
+
+/mob/proc/add_bump_attacks()
+	return
+
+/mob/living/carbon/xenomorph/add_bump_attacks()
+	if(CONFIG_GET(flag/bump_attacks))
+		AddComponent(/datum/component/bump_attack)
+
+/mob/living/carbon/xenomorph/add_abilities()
+	add_bump_attacks()
+	. = ..()

--- a/modular/bump_attacks/code/bump_attacks_mob.dm
+++ b/modular/bump_attacks/code/bump_attacks_mob.dm
@@ -1,5 +1,5 @@
 /mob/proc/remove_bump_attacks()
-	var/datum/component/bump_attacks/component = player.GetComponent(/datum/component/bump_attack)
+	var/datum/component/bump_attack/component = GetComponent(/datum/component/bump_attack)
 	if(component)
 		qdel(component)
 

--- a/modular/bump_attacks/code/bump_attacks_statistics.dm
+++ b/modular/bump_attacks/code/bump_attacks_statistics.dm
@@ -1,0 +1,2 @@
+/datum/entity/statistic/round
+	var/xeno_bump_attacks = 0

--- a/modular/modular.dme
+++ b/modular/modular.dme
@@ -6,7 +6,7 @@
 #include "_signals220/_signals220.dme"
 #include "_singletons/_singletons.dme"
 #include "changelog/_changelog.dme"
-// #include "bump_attacks/_bump_attacks.dme"
+#include "bump_attacks/_bump_attacks.dme"
 #include "cyrillic_fixes/_cyrillic_fixes.dme"
 #include "respawn/_respawn.dme"
 #include "sounds/_sounds.dme"

--- a/nano/templates/cm_stat_panel.tmpl
+++ b/nano/templates/cm_stat_panel.tmpl
@@ -165,6 +165,12 @@ Used in: /code/datums/statistics/entities/player_entity.dm
                 <div class="itemContentSmallRight">
                     {{:data.round.total_slashes}}
                 </div>
+				<div class="itemLabelClear">
+                    Total Xeno Bump Attacks:
+                </div>
+				<div class="itemContentSmallRight">
+                    {{:data.round.xeno_bump_attacks}}
+                </div>
                 <div class="itemLabelClear">
                     Total Facehuggers Applied:
                 </div>


### PR DESCRIPTION
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->
## Что этот PR делает
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Переносит бамп атаки в конфиг, а также дает возможность включать/выключать их во время раунда через Admin -> Toggle Bump Attacks

## Почему это хорошо для игры
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

В целом, бамп атаки нужны для людей, у которых сложности кликать по модельке/использовать направленные удары.

Опытные игроки/молодые геймеры/задроты не имеют проблем с затыкиванием, потому, добавление бамп атак никак не влияет на топ 10% игроков. Но эти же бамп атаки позволяют уже пожилым геймерам/геймерам с проблемами со здоровьем насладиться игрой за касты ближнего боя. Мне вот именно этих игроков жаль - а среди них могут быть фанаты чужих. Они ХОТЯТ ходить и резать маринад, но физически им это очень сложно даётся.

Чтобы уменьшить эффективность бамп атак на быстрых кастах (мои бедные руни), добавлена задержка передвижения. Посмотрим в будущем, как оно себя проявит.

## Changelog

:cl:
add: Количество бамп атак теперь должно появиться в раунд-энд статистике
balance: При нанесении атаки бамп-атакой, вы не сможете двигаться дополнительно 0.5 секунд
balance: Бамп атаки теперь не могут дизармить
config: Добавлено значение BUMP_ATTACKS, которое по-умолчанию выключено
admin: Добавлен верб Toggle Bump Attacks, который включает/выключает бамп атаки на сервере
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
