### PR TITLE
TTS now correctly disables via config

### DIFF
--- a/modular/text_to_speech/code/configuration.dm
+++ b/modular/text_to_speech/code/configuration.dm
@@ -1,12 +1,7 @@
 /// Is TTS enabled
 /datum/config_entry/flag/tts_enabled
-	config_entry_value = TRUE
+	config_entry_value = FALSE
 	protection = CONFIG_ENTRY_HIDDEN
-
-// /datum/config_entry/flag/tts_enabled/New()
-// 	. = ..()
-// 	tts_enabled = CONFIG_GET(string/tts_token_silero) && SStts220.is_enabled
-
 
 /// TTS API token for silero provider
 /datum/config_entry/string/tts_token_silero

--- a/modular/text_to_speech/code/tts_subsystem.dm
+++ b/modular/text_to_speech/code/tts_subsystem.dm
@@ -278,9 +278,9 @@ SUBSYSTEM_DEF(tts220)
 	tts_seeds_names = sortTim(tts_seeds_names, /proc/cmp_text_asc)
 
 /datum/controller/subsystem/tts220/Initialize(start_timeofday)
-	is_enabled = SStts220.is_enabled
-	if(!is_enabled)
-		flags |= SS_NO_FIRE
+	if(!CONFIG_GET(flag/tts_enabled))
+		is_enabled = FALSE
+		return SS_INIT_NO_NEED
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/tts220/fire()


### PR DESCRIPTION

## Что этот PR делает
Меньше рантаймов на локалке без ТТС

## Changelog

:cl:
config: Теперь флаг tts_enabled работает корректно
/:cl:
