### PR TITLE
Фикс квик-каста

### DIFF
--- a/modular/quick_cast/code/quick_cast.dm
+++ b/modular/quick_cast/code/quick_cast.dm
@@ -14,6 +14,9 @@
 	if(istype(target, /atom/movable/screen/action_button)){\
 		return ..();\
 	}\
+	if(istype(target, /atom/movable/screen/click_catcher)){\
+		return ..();\
+	}\
 	if(istype(target, /atom/movable/screen)){\
 		return;\
 	}\


### PR DESCRIPTION

## Что этот PR делает
Я профессионально забыл залить возможность переключать способности, когда ты нажимаешь на черноту с квик-кастом
## Почему это хорошо для игры
мощь
## Изображения изменений
вставьте сюда смешную картинку с котиком
## Тестирование
нажимаю на клик-катчер с включённым квик-кастом - и способность переключается, всё работает
## Changelog

:cl:
qol: Квик-каст теперь позволяет переключать способность при нажатии на туман войны
/:cl:
