### PR TITLE
Revert "Add check new players in verbs & improve it"

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -303,7 +303,6 @@ GLOBAL_LIST_INIT(admin_verbs_teleport, list(
 ))
 
 GLOBAL_LIST_INIT(mentor_verbs, list(
-	/client/proc/cmd_mentor_check_new_players, // BANDAMARINES ADDITION
 	/client/proc/cmd_mentor_say,
 	/datum/admins/proc/imaginary_friend,
 	/client/proc/toggle_newplayer_ghost_hud,

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -5,7 +5,7 @@
 
 /client/proc/cmd_mentor_check_new_players() //Allows mentors / admins to determine who the newer players are.
 	set category = "Admin"
-	set name = "Check New Players"
+	set name = "Check new Players"
 
 	if(!admin_holder)
 		to_chat(src, "You do not have permission to use this.")
@@ -18,34 +18,25 @@
 		if(!CONFIG_GET(flag/mentor_tools))
 			to_chat(src, "Mentors do not have permission to use this.")
 
-	var/age = input(src, "Show accounts younger then ___ days", "Age check") as num|null
-	var/playtime_hours = input(src, "Show accounts with less than ___ hours", "Playtime check") as num|null
-	if(isnull(age))
-		age = -1
-	if(isnull(playtime_hours))
-		playtime_hours = -1
-	if(age <= 0 && playtime_hours <= 0)
-		return
+	var/age = alert(src, "Age check", "Show accounts up to how many days old ?", "7", "30" , "All")
+
+	if(age == "All")
+		age = 9999999
+	else
+		age = text2num(age)
 
 	var/missing_ages = FALSE
 	var/msg = ""
 
 	for(var/client/C in GLOB.clients)
-		if(CLIENT_IS_STEALTHED(src) && !CLIENT_IS_STAFF(src))
-			continue // Skip those in stealth mode if an admin isnt viewing the panel
-		if(!isnum(C.player_age))
-			missing_ages = TRUE
+		if(C.player_age == "Requires database")
+			missing_ages = 1
 			continue
 		if(C.player_age < age)
 			msg += "[key_name(C, 1, 1, CLIENT_IS_STAFF(src))]: account is [C.player_age] days old<br>"
 
-		var/client_hours = get_total_living_playtime(C)
-		client_hours /= 60 // minutes to hours
-		if(client_hours < playtime_hours)
-			msg += "[key_name(C, 1, 1, CLIENT_IS_STAFF(src))]: [client_hours] living + ghost hours<br>"
-
 	if(missing_ages)
-		to_chat(src, "Some accounts did not have proper ages set in their clients. This function requires database to be present.")
+		to_chat(src, "Some accounts did not have proper ages set in their clients.  This function requires database to be present")
 
 	if(msg != "")
 		show_browser(src, msg, "Check New Players", "Player_age_check")


### PR DESCRIPTION
Не работает
Reverts ss220club/BandaMarines#125

## Краткое описание от Sourcery

Отменяет добавление глагола 'Check New Players' и связанных с ним изменений из-за его некорректной работы.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reverts the addition of the 'Check New Players' verb and related changes due to it not working as expected.

</details>