### PR TITLE
Vehicle restriction removal

### DIFF
--- a/code/modules/cm_tech/techs/marine/tier1/arc.dm
+++ b/code/modules/cm_tech/techs/marine/tier1/arc.dm
@@ -16,11 +16,11 @@
 /datum/tech/arc/can_unlock(mob/unlocking_mob)
 	. = ..()
 
-	var/obj/structure/machinery/cm_vending/gear/vehicle_crew/gearcomp = GLOB.VehicleGearConsole
+	//var/obj/structure/machinery/cm_vending/gear/vehicle_crew/gearcomp = GLOB.VehicleGearConsole
 
-	if(gearcomp.selected_vehicle == "TANK")
-		to_chat(unlocking_mob, SPAN_WARNING ("A vehicle has already been selected for this operation."))
-		return FALSE
+	//if(gearcomp.selected_vehicle == "TANK")
+	//	to_chat(unlocking_mob, SPAN_WARNING ("A vehicle has already been selected for this operation."))
+	//	return FALSE
 
 	return TRUE
 


### PR DESCRIPTION

## Что этот PR делает
Убирает запрет на покупку танка если уже есть единица техники.
## Почему это хорошо для игры
Добавляем больше техники в раунд!
## Изображения изменений
## Тестирование
## Changelog

:cl:
add: Добавил возможность марам покупать бтр и танк в одном раунде
balance: добавил марам возможность покупать и бтр, и танк в одном и том же раунде
/:cl:
