### PR TITLE
[TM ONLY] Two SADAR kits

### DIFF
--- a/code/modules/cm_marines/specialist.dm
+++ b/code/modules/cm_marines/specialist.dm
@@ -135,6 +135,7 @@
 	skill_to_give = SKILL_SPEC_ROCKET
 	trait_to_give = "demo"
 	kit_typepath = /obj/item/storage/box/spec/demolitionist
+	available_vendor_num = 2 // SS220 EDIT
 
 /datum/specialist_set/sadar/redeem_set(mob/living/redeemer, kit)
 	. = ..()


### PR DESCRIPTION
## Что этот PR делает
Дает возможность взять кит садара два раза, не изменяя общее число специалистов
## Тестирование
Локальные тесты
## Changelog

:cl:
add: Садары стронг
/:cl:

## Обзор от Sourcery

Улучшения:
- Позволяет брать наборы SADAR дважды.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Allows SADAR kits to be taken twice.

</details>