### PR TITLE
arc skill lower

### DIFF
--- a/code/modules/vehicles/arc/arc.dm
+++ b/code/modules/vehicles/arc/arc.dm
@@ -26,7 +26,7 @@
 
 	entrance_speed = 0.5 SECONDS
 
-	required_skill = SKILL_VEHICLE_LARGE
+	required_skill = SKILL_VEHICLE_DEFAULT
 
 	movement_sound = 'sound/vehicles/tank_driving.ogg'
 


### PR DESCRIPTION

## Что этот PR делает
Понижает значение навыка вождения рак до единицы
## Почему это хорошо для игры
Теперь больше людей могут ездить на арк.
## Изображения изменений
## Тестирование
## Changelog

:cl:
add: Исправил значение скилла навыка вождения с двух до одного на арк
/:cl:
