### PR TITLE
Allow cyrillic in sec records

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -432,7 +432,7 @@
 			"type" = "string",
 			"max_length" = 49,
 			"required" = TRUE,
-			"regex" = regex(@"^[a-zA-Z' ]+$"), // Allow letters, spaces, and single quotes
+			"regex" = regex(@"^[a-zA-Zа-яА-Я' ]+$"), // Allow letters, spaces, and single quotes
 		),
 		"general_rank" = list(
 			"type" = "string",

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -432,7 +432,7 @@
 			"type" = "string",
 			"max_length" = 49,
 			"required" = TRUE,
-			"regex" = regex(@"^[a-zA-Zа-яА-Я' ]+$"), // Allow letters, spaces, and single quotes
+			"regex" = regex(@"^[a-zA-Zа-яёА-ЯЁ' ]+$"), // Allow letters, spaces, and single quotes
 		),
 		"general_rank" = list(
 			"type" = "string",


### PR DESCRIPTION
## Что этот PR делает
Разрешает кирилицу в консоли МП
Fixes #176 
## Тестирование
Локальные тесты
## Changelog

:cl:
fix: Разрешена кирилица в консоли МП
/:cl:

## Обзор от Sourcery

Исправления ошибок:
- Исправлена проблема, из-за которой кириллические символы не были разрешены в записях безопасности.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where cyrillic characters were not allowed in security records.

</details>