### PR TITLE
Добавляет камеру M5 в вендоры СЛ-ов.

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_leader.dm
@@ -112,6 +112,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_leader, list(
 		list("Intel Radio Encryption Key", 3, /obj/item/device/encryptionkey/intel, null, VENDOR_ITEM_REGULAR),
 		list("JTAC Radio Encryption Key", 3, /obj/item/device/encryptionkey/jtac, null, VENDOR_ITEM_REGULAR),
 		list("Supply Radio Encryption Key", 3, /obj/item/device/encryptionkey/req, null, VENDOR_ITEM_REGULAR),
+		list("M5 Camera Gear", 3, /obj/item/device/overwatch_camera, null, VENDOR_ITEM_REGULAR),
 	))
 
 /obj/structure/machinery/cm_vending/gear/leader


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# Добавляет камеру M5 в вендоры СЛ-ов.

Собственно добавляет камеру M5 в вендоры СЛ-ов.

# Почему это хорошо для игры.

Меньше конфликтов и ситуаций когда СЛ забыл дома шапку ушанку с ultraquadroHD камерой.


# Фото

![m5](https://github.com/user-attachments/assets/09cec1e5-8217-4821-80e5-cee21de6a289)



# Чейнджлог

Одна новая строчка.

:cl:
add: Adds M5 Camera Gear to the squad leader vendors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->


## Обзор от Sourcery

Новые функции:
- Добавлено снаряжение для камеры M5 к торговцам лидера отряда.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Adds M5 Camera Gear to the squad leader vendors.

</details>