### PR TITLE
Фикс перевода ГЛАВНОГО инженера, а не старшего

### DIFF
--- a/code/__DEFINES/bandamarines/ru_jobs.dm
+++ b/code/__DEFINES/bandamarines/ru_jobs.dm
@@ -80,7 +80,7 @@
 
 #define JOB_SEA_RU "Старший Инструктор"
 
-#define JOB_CHIEF_ENGINEER_RU "Старший Инженер"
+#define JOB_CHIEF_ENGINEER_RU "Главный Инженер"
 #define JOB_MAINT_TECH_RU "Техник Обслуживания"
 #define JOB_ORDNANCE_TECH_RU "Оружейный Техник"
 

--- a/tgui/packages/tgui/interfaces/BandaMarines/MarineJobs.tsx
+++ b/tgui/packages/tgui/interfaces/BandaMarines/MarineJobs.tsx
@@ -114,7 +114,7 @@ const JOBS_RU = {
   'Chief MP': 'Шеф Военной Полиции',
 
   // Engineering roles
-  'Chief Engineer': 'Старший Инженер',
+  'Chief Engineer': 'Главный Инженер',
   'Maintenance Technician': 'Техник Обслуживания',
   'Ordnance Technician': 'Оружейный Техник',
 


### PR DESCRIPTION

## Что этот PR делает
Изменил названия джобки ЧИФ ИНГИНЕЕР с старшего на главного.
## Почему это хорошо для игры
Потому что на военном судне не может быть старший без главного. Тем более старший в звании лейтенанта. Тем более офицер.

## Changelog

:cl:
fix: Никаких старших инженеров без главных инженеров
/:cl:
