### PR TITLE
Nuclear marines count lock

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -132,3 +132,11 @@
 	min_val = 0
 	config_entry_value = 140
 	integer = TRUE
+
+// SS220 ADD - START
+/datum/config_entry/number/nuclear_lock_marines_percentage
+	config_entry_value = 40
+	integer = TRUE
+	min_val = 1
+	max_val = 100
+// SS220 ADD - END

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -135,7 +135,7 @@
 
 // SS220 ADD - START
 /datum/config_entry/number/nuclear_lock_marines_percentage
-	config_entry_value = 50
+	config_entry_value = 30
 	integer = TRUE
 	min_val = 1
 	max_val = 100

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -135,7 +135,7 @@
 
 // SS220 ADD - START
 /datum/config_entry/number/nuclear_lock_marines_percentage
-	config_entry_value = 30
+	config_entry_value = 50
 	integer = TRUE
 	min_val = 1
 	max_val = 100

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -135,7 +135,7 @@
 
 // SS220 ADD - START
 /datum/config_entry/number/nuclear_lock_marines_percentage
-	config_entry_value = 40
+	config_entry_value = 30
 	integer = TRUE
 	min_val = 1
 	max_val = 100

--- a/code/game/machinery/ARES/ARES_interface.dm
+++ b/code/game/machinery/ARES/ARES_interface.dm
@@ -439,7 +439,7 @@
 			var/marines_count = SSticker.mode.count_marines() // Подсчитываем маринов на земле и на корабле
 			var/marines_peak = GLOB.peak_humans * CONFIG_GET(number/nuclear_lock_marines_percentage) / 100
 			if(marines_count >= marines_peak)
-				to_chat(user, SPAN_WARNING("В запросе ядерного устройства отказано! На земле еще еще слишком много живых морпехов!"))
+				to_chat(user, SPAN_WARNING("В запросе ядерного устройства отказано! На этой операции еще еще слишком много живых морпехов и экипажа USCM!"))
 				playsound(src, 'sound/machines/buzz-two.ogg', 15, 1)
 				return FALSE
 			// SS220 EDIT - END

--- a/code/game/machinery/ARES/ARES_interface.dm
+++ b/code/game/machinery/ARES/ARES_interface.dm
@@ -437,7 +437,7 @@
 				return FALSE
 			// SS220 EDIT - START
 			var/players_count = SSticker.mode.count_marines() // Подсчитываем маринов на земле и на корабле
-			if(players_count <= (GLOB.peak_humans * CONFIG_GET(number/nuclear_lock_marines_percentage)))
+			if(players_count >= (GLOB.peak_humans * CONFIG_GET(number/nuclear_lock_marines_percentage)))
 				to_chat(user, SPAN_WARNING("В запросе ядерного устройства отказано! На земле еще еще слишком много живых морпехов!"))
 				playsound(src, 'sound/machines/buzz-two.ogg', 15, 1)
 				return FALSE

--- a/code/game/machinery/ARES/ARES_interface.dm
+++ b/code/game/machinery/ARES/ARES_interface.dm
@@ -436,8 +436,9 @@
 				playsound(src, 'sound/machines/buzz-two.ogg', 15, 1)
 				return FALSE
 			// SS220 EDIT - START
-			var/players_count = SSticker.mode.count_marines() // Подсчитываем маринов на земле и на корабле
-			if(players_count >= (GLOB.peak_humans * CONFIG_GET(number/nuclear_lock_marines_percentage) / 100))
+			var/marines_count = SSticker.mode.count_marines() // Подсчитываем маринов на земле и на корабле
+			var/marines_peak = GLOB.peak_humans * CONFIG_GET(number/nuclear_lock_marines_percentage) / 100
+			if(marines_count >= marines_peak)
 				to_chat(user, SPAN_WARNING("В запросе ядерного устройства отказано! На земле еще еще слишком много живых морпехов!"))
 				playsound(src, 'sound/machines/buzz-two.ogg', 15, 1)
 				return FALSE

--- a/code/game/machinery/ARES/ARES_interface.dm
+++ b/code/game/machinery/ARES/ARES_interface.dm
@@ -437,7 +437,7 @@
 				return FALSE
 			// SS220 EDIT - START
 			var/players_count = SSticker.mode.count_marines() // Подсчитываем маринов на земле и на корабле
-			if(players_count >= (GLOB.peak_humans * CONFIG_GET(number/nuclear_lock_marines_percentage)))
+			if(players_count >= (GLOB.peak_humans * CONFIG_GET(number/nuclear_lock_marines_percentage) / 100))
 				to_chat(user, SPAN_WARNING("В запросе ядерного устройства отказано! На земле еще еще слишком много живых морпехов!"))
 				playsound(src, 'sound/machines/buzz-two.ogg', 15, 1)
 				return FALSE

--- a/code/game/machinery/ARES/ARES_interface.dm
+++ b/code/game/machinery/ARES/ARES_interface.dm
@@ -424,25 +424,32 @@
 			if(!SSticker.mode)
 				return FALSE //Not a game mode?
 			if(world.time < NUCLEAR_TIME_LOCK)
-				to_chat(user, SPAN_WARNING("It is too soon to request Nuclear Ordnance!"))
+				to_chat(user, SPAN_WARNING("Вы слишком рано запрашиваете ядерное устройство!")) // SS220 EDIT TRANSLATE
 				playsound(src, 'sound/machines/buzz-two.ogg', 15, 1)
 				return FALSE
 			if(!COOLDOWN_FINISHED(datacore, ares_nuclear_cooldown))
-				to_chat(user, SPAN_WARNING("The ordnance request frequency is garbled, wait for reset!"))
+				to_chat(user, SPAN_WARNING("Снизьте частоту вызова ядерного устройства и дождитесь перезапуска!")) // SS220 EDIT TRANSLATE
 				playsound(src, 'sound/machines/buzz-two.ogg', 15, 1)
 				return FALSE
 			if(GLOB.security_level == SEC_LEVEL_DELTA || SSticker.mode.is_in_endgame)
-				to_chat(user, SPAN_WARNING("The mission has failed catastrophically, what do you want a nuke for?!"))
+				to_chat(user, SPAN_WARNING("Эта миссия - катастрофа! Полный провал! Зачем вам еще и ядерная бомба?!")) // SS220 EDIT TRANSLATE
 				playsound(src, 'sound/machines/buzz-two.ogg', 15, 1)
 				return FALSE
-			var/reason = tgui_input_text(user, "Please enter reason nuclear ordnance is required.", "Reason for Nuclear Ordnance")
+			// SS220 EDIT - START
+			var/players_count = SSticker.mode.count_marines() // Подсчитываем маринов на земле и на корабле
+			if(players_count <= (GLOB.peak_humans * CONFIG_GET(number/nuclear_lock_marines_percentage)))
+				to_chat(user, SPAN_WARNING("В запросе ядерного устройства отказано! На земле еще еще слишком много живых морпехов!"))
+				playsound(src, 'sound/machines/buzz-two.ogg', 15, 1)
+				return FALSE
+			// SS220 EDIT - END
+			var/reason = tgui_input_text(user, "Укажите причину запроса ядерного устройства.", "Причина для Ядерного Устройства")// SS220 EDIT TRANSLATE
 			if(!reason)
 				return FALSE
 			for(var/client/admin in GLOB.admins)
 				if((R_ADMIN|R_MOD) & admin.admin_holder.rights)
 					playsound_client(admin,'sound/effects/sos-morse-code.ogg',10)
 			message_admins("[key_name(user)] has requested use of Nuclear Ordnance (via ARES)! Reason: <b>[reason]</b> [CC_MARK(user)] (<A href='byond://?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];nukeapprove=\ref[user]'>APPROVE</A>) (<A href='byond://?_src_=admin_holder;[HrefToken(forceGlobal = TRUE)];nukedeny=\ref[user]'>DENY</A>) [ADMIN_JMP_USER(user)] [CC_REPLY(user)]")
-			to_chat(user, SPAN_NOTICE("A nuclear ordnance request has been sent to USCM High Command for the following reason: [reason]"))
+			to_chat(user, SPAN_NOTICE("Запрос на ядерное устройство был отправлен в Верховное Командование ККМП по следующей причине: [reason]"))
 			log_ares_security("Nuclear Ordnance Request", "Sent a request for nuclear ordnance for the following reason: [reason]", last_login)
 			if(ares_can_interface())
 				ai_silent_announcement("[last_login] направил запрос на ядерный арсенал Верховному командованию КМП.", ".V")

--- a/code/modules/cm_tech/techs/marine/tier4/nuke.dm
+++ b/code/modules/cm_tech/techs/marine/tier4/nuke.dm
@@ -39,6 +39,14 @@
 		to_chat(unlocking_mob, SPAN_WARNING("You cannot purchase this node before [ceil((NUKE_UNLOCK_TIME + SSticker.round_start_time) / (1 MINUTES))] minutes into the operation."))
 		return FALSE
 
+	// SS220 EDIT - START
+	var/marines_count = SSticker.mode.count_marines() // Подсчитываем маринов на земле и на корабле
+	var/marines_peak = GLOB.peak_humans * CONFIG_GET(number/nuclear_lock_marines_percentage) / 100
+	if(marines_count >= marines_peak)
+		to_chat(unlocking_mob, SPAN_WARNING("Вы не можете запросить устройство ядерной аутентификации, пока живо больше чем [marines_peak] морпехов и экипажа USCM на этой операции."))
+		return FALSE
+	// SS220 EDIT - END
+
 	return TRUE
 
 /datum/tech/nuke/proc/handle_description()


### PR DESCRIPTION
## Что этот PR делает
Ограничиваем вызов ядерки на количестве игроков от процента живых игроков.
Значение выставляем в конфиге
Связан с https://github.com/ss220club/BandaMarines/pull/141

## Почему это хорошо для игры
Больше никаких вызово ядерок пока марины живы. Га-га-га
## Изображения изменений
## Тестирование
ПРотестировано, куклы USCM считаются. Пик плееров тоже.
Но билд запустился
## Changelog

:cl:
add: Ограничение вызова ядерки, пока жив определенный процент маринов.
/:cl:
