### PR TITLE
[TM] Offline timed ban

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -75,7 +75,8 @@ GLOBAL_LIST_INIT(admin_verbs_default, list(
 	/client/proc/add_known_alt,
 	/client/proc/remove_known_alt,
 	/client/proc/toogle_door_control,
-	/client/proc/check_new_players, // SS220 EDIT
+	/client/proc/check_new_players, // SS220 ADD
+	/client/proc/offline_timed_ban, // SS220 ADD
 	))
 
 GLOBAL_LIST_INIT(admin_verbs_admin, list(

--- a/modular/admin/_admin.dme
+++ b/modular/admin/_admin.dme
@@ -1,3 +1,4 @@
 #include "_admin.dm"
 
 #include "code/check_new_players.dm"
+#include "code/offline_timed_ban.dm"

--- a/modular/admin/code/offline_timed_ban.dm
+++ b/modular/admin/code/offline_timed_ban.dm
@@ -1,0 +1,27 @@
+/client/proc/offline_timed_ban()
+	set name = "Offline Timed Ban"
+	set category = "Admin"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	var/datum/offline_timed_ban/offline_timed_ban = new
+	offline_timed_ban.add_offline_timed_ban()
+
+/datum/offline_timed_ban/proc/add_offline_timed_ban()
+	var/ckey = ckey(tgui_input_text(usr, "Ckey to ban? Enter key or ckey", "Ckey to ban"))
+	if(!ckey)
+		return
+
+	var/mins = tgui_input_number(usr, "How long (in minutes)? 180 = 3 hours, 1440 = 1 day,  4320 = 3 days, 10080 = 7 days, 43800 = 1 Month", "Ban time", 1440, 262800, 1)
+	if(!mins)
+		return
+
+	var/reason = tgui_input_text(usr, "Reason? Press 'OK' to finalize the ban.", "Ban reason", "Griefer")
+	if(!reason)
+		return
+
+	var/datum/entity/player/player = get_player_from_key(ckey)
+	if(player.is_time_banned && alert(usr, "Ban already exists. Proceed?", "Confirmation", "Yes", "No") != "Yes")
+		return
+	player.add_timed_ban(reason, mins)


### PR DESCRIPTION
## Что этот PR делает
Добавляет возможность выдавать временные баны оффлайн игрокам
Closes #207
## Тестирование
Локальные тесты
## Changelog
:cl:
admin: Возможность выдавать временные баны оффлайн игрокам
/:cl:

## Summary by Sourcery

Новые функции:
- Введение возможности выдачи временных банов оффлайн-игрокам.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce the ability to issue timed bans to offline players.

</details>