### PR TITLE
Tweak Speech filter

### DIFF
--- a/modular/speech_filter/code/speech_filter.dm
+++ b/modular/speech_filter/code/speech_filter.dm
@@ -30,7 +30,8 @@
 		html = "\n<font color='red' size='2'><b>Ваше сообщение было автоматически отфильтровано из-за его содержания. Попытка обойти этот фильтр приведет к бану.</b></font>",
 		)
 	SEND_SOUND(user, sound('sound/effects/adminhelp_new.ogg'))
-	log_admin("[user.ckey] попытался сказать запретное слово: [original_message].")
+	log_admin("[key_name(user)] попытался сказать запретное слово: [original_message].")
+	message_admins("[key_name_admin(user)] попытался сказать запретное слово: [original_message].")
 
 	if(ishuman(user))
 		var/mob/living/L = user


### PR DESCRIPTION
## Что этот PR делает
Tweak Speech filter
## Тестирование
Локальные тесты
## Changelog

:cl:
admin: Tweaked Speech filter
/:cl:

## Обзор от Sourcery

Обновляет фильтр речи для улучшения логирования, добавляя имя ключа пользователя в логи администратора и транслируя сообщение администраторам, когда пользователь пытается произнести запрещенное слово.

Улучшения:
- Улучшено логирование отфильтрованной речи путем включения имени ключа пользователя.
- Транслируется сообщение администраторам, когда пользователь пытается произнести запрещенное слово.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Updates the speech filter to improve logging by including the user's key name in admin logs and broadcasts a message to admins when a user attempts to say a forbidden word.

Enhancements:
- Improve logging of filtered speech by including the user's key name.
- Broadcast a message to admins when a user attempts to say a forbidden word.

</details>