### PR TITLE
[TM ONLY] Fix: Танк больше не сможет двигаться, если у него не установлены гусеницы.

### DIFF
--- a/code/modules/vehicles/tank/tank.dm
+++ b/code/modules/vehicles/tank/tank.dm
@@ -143,6 +143,15 @@
 //Another wrapper for try_move()
 /obj/vehicle/multitile/tank/relaymove(mob/user, direction)
 	if(user == seats[VEHICLE_DRIVER])
+		// Check if treads are installed
+		var/has_treads = FALSE
+		for(var/h in hardpoints)
+			if(istype(h, /obj/item/hardpoint/locomotion/treads))
+				has_treads = TRUE
+				break
+		if(!has_treads)
+			return FALSE // Block movement if no treads installed
+
 		return ..()
 
 	if(user != seats[VEHICLE_GUNNER])


### PR DESCRIPTION
## Что этот PR делает
Оригинальный ПР у оффов https://github.com/cmss13-devs/cmss13/pull/9079
Этот PR исправляет баг, при котором танк мог сдвинуться на одну клетку без установленных гусениц, после чего "зависал" и больше не мог двигаться — даже если гусеницы потом ставили.

Теперь перед движением добавлена проверка: если у танка нет гусениц, он просто не сможет поехать.
## Почему это хорошо для игры
Больше нельзя случайно сломать или брикнуть танк из-за отсутствия гусениц.
## Изображения изменений
## Тестирование
Проверено локально — всё работает как надо.
## Changelog

:cl:
fix: Танк больше не сможет двигаться, если у него не установлены гусеницы.
/:cl: