### PR TITLE
Fixes for medal recomendation modal

### DIFF
--- a/tgui/packages/tgui/components/TextArea.tsx
+++ b/tgui/packages/tgui/components/TextArea.tsx
@@ -28,6 +28,7 @@ type Props = Partial<{
   fluid: boolean;
   maxLength: number;
   noborder: boolean;
+  noResize: boolean;
   /** Fires when user is 'done typing': Clicked out, blur, enter key (but not shift+enter) */
   onChange: (event: SyntheticEvent<HTMLTextAreaElement>, value: string) => void;
   /** Fires once the enter key is pressed */
@@ -62,7 +63,13 @@ export const TextArea = forwardRef(
       value,
       ...boxProps
     } = props;
-    const { className, fluid, nowrap, ...rest } = boxProps;
+    const {
+      className,
+      fluid,
+      nowrap,
+      noResize,
+      ...rest
+    } = boxProps;
 
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const [scrolledAmount, setScrolledAmount] = useState(0);
@@ -131,10 +138,14 @@ export const TextArea = forwardRef(
     /** Updates the initial value on props change */
     useEffect(() => {
       const input = textareaRef.current;
-      if (!input) return;
+      if (!input) {
+        return;
+      }
 
       const newValue = toInputValue(value);
-      if (input.value === newValue) return;
+      if (input.value === newValue) {
+        return;
+      }
 
       input.value = newValue;
     }, [value]);
@@ -176,10 +187,11 @@ export const TextArea = forwardRef(
             'TextArea__textarea',
             scrollbar && 'TextArea__textarea--scrollable',
             nowrap && 'TextArea__nowrap',
+            noResize && 'TextArea--noresize',
           ])}
           maxLength={maxLength}
           onBlur={(event) => onChange?.(event, event.target.value)}
-          onChange={(event) => onInput?.(event, event.target.value)}
+          onChange={(event) => onInput?.(event, event.target.value.replace(/"/g, ''))}
           onKeyDown={handleKeyDown}
           onScroll={() => {
             if (displayedValue && textareaRef.current) {

--- a/tgui/packages/tgui/interfaces/TextInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/TextInputModal.tsx
@@ -110,13 +110,15 @@ const InputArea = (props: {
       autoSelect
       height={multiline || input.length >= 30 ? '100%' : '1.8rem'}
       maxLength={max_length}
+      noResize
       onEscape={() => act('cancel')}
       onEnter={(event: KeyboardEvent<HTMLTextAreaElement>) => {
         if (visualMultiline && event.shiftKey) {
           return;
         }
         event.preventDefault();
-        act('submit', { entry: input });
+
+        act('submit', { entry: input.replace(/"/g, '') });
       }}
       onChange={(_, value) => onType(value)}
       onInput={(_, value) => onType(value)}

--- a/tgui/packages/tgui/interfaces/common/InputButtons.tsx
+++ b/tgui/packages/tgui/interfaces/common/InputButtons.tsx
@@ -26,6 +26,9 @@ export const InputButtons = (props: InputButtonsProps) => {
       if (submit_disabled) {
         return;
       }
+      if (typeof input === 'string') {
+        input.replace(/"/g, '');
+      }
       act('submit', { entry: input });
     };
   }

--- a/tgui/packages/tgui/styles/components/TextArea.scss
+++ b/tgui/packages/tgui/styles/components/TextArea.scss
@@ -35,6 +35,10 @@ $border-radius: Input.$border-radius !default;
   border: 0px;
 }
 
+.TextArea--noresize {
+  resize: none;
+}
+
 .TextArea__textarea.TextArea__textarea--scrollable {
   overflow: auto;
   overflow-x: hidden;


### PR DESCRIPTION
fixes [#BandaMarines/278](https://github.com/ss220club/BandaMarines/issues/278)

# About the pull request

Fixes a TGUI bug where it was possible to resize the text area separately from the modal window. And a TGUI bug that made it impossible to send a message to the backend if the input text contained the " character .

# Explain why it's good for the game

Fixes bugs, better UX

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/user-attachments/assets/d8b5154e-e150-42dc-9793-7415a3958b62)

After sending

![image](https://github.com/user-attachments/assets/63e5ceef-6178-4274-98fa-1c5773889299)


</details>


# Changelog

:cl:
fix: Ability to resize the TGUI TextArea in the modal box medal recommendation and failure to send this due to the " char
/:cl:

## Обзор от Sourcery

Исправление проблем с модальным вводом TGUI путем предотвращения изменения размера текстовой области и обработки проблемных символов кавычек.

Исправления ошибок:
- Запретить пользователям изменять размер текстовой области в модальном окне рекомендаций медалей.
- Удалить символы двойных кавычек из ввода для решения проблем с отправкой.

Улучшения:
- Улучшена обработка текстового ввода в модальных окнах TGUI.
- Добавлена очистка ввода для специальных символов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix TGUI modal input issues by preventing textarea resizing and handling problematic quote characters

Bug Fixes:
- Prevent users from resizing the text area in medal recommendation modal
- Remove double quote characters from input to resolve submission issues

Enhancements:
- Improve text input handling in TGUI modals
- Add input sanitization for special characters

</details>