### PR TITLE
В зелёной кассете не хватает песен

### DIFF
--- a/code/game/objects/items/devices/walkman.dm
+++ b/code/game/objects/items/devices/walkman.dm
@@ -464,10 +464,12 @@
 	side1_icon = "cassette_green"
 	songs = list("side1" = list("sound/music/walkman/nam/9-1-1.ogg",\
 								"sound/music/walkman/nam/9-1-2.ogg",\
-								"sound/music/walkman/nam/9-1-3.ogg"),\
+								"sound/music/walkman/nam/9-1-3.ogg", //SS220 - EDIT
+								"sound/music/walkman/nam/9-1-4.ogg"), //SS220 - EDIT
 				"side2" = list("sound/music/walkman/nam/9-2-1.ogg",\
 								"sound/music/walkman/nam/9-2-2.ogg",\
-								"sound/music/walkman/nam/9-2-3.ogg"))
+								"sound/music/walkman/nam/9-2-3.ogg", //SS220 - EDIT
+								"sound/music/walkman/nam/9-2-4.ogg")) //SS220 - EDIT
 
 /obj/item/device/cassette_tape/ocean
 	name = "ocean cassette"


### PR DESCRIPTION
fix #143 
## Что этот PR делает

Исправление кол-ва треков в зеленой кассете

## Почему это хорошо для игры

Улучшает UX и атмосферу для игроков, использующих плеер в игре

<details>
<summary>Скриншоты и видео</summary>

https://github.com/user-attachments/assets/8a5efa29-e383-4e17-b958-f1ca681980e6

</details>

## Тестирование

взять зеленую кассету, взять плеер, запустить, убедиться что в кассете 4 трека

## Changelog

:cl:
fix: исправлено кол-во треков у зеленой кассеты
/:cl:
