### PR TITLE
[TM] Ghost TTS doesn't check GhostEars prefs anymore

### DIFF
--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -57,11 +57,12 @@
 			track += "(<a href='byond://?src=\ref[src];track=\ref[queen_eye]'>E</a>) "
 	if(client && client.prefs && client.prefs.toggles_chat & CHAT_GHOSTEARS && speaker.z == z && get_dist(speaker, src) <= GLOB.world_view_size)
 		message = "<b>[message]</b>"
-		speaker.cast_tts(src, message) // SS220 ADDITION
 
 	// BANDAMARINES EDIT START
 	if(speaker_name == speaker.name)
 		speaker_name = speaker.declent_ru(NOMINATIVE)
+	if(client && speaker.z == z && get_dist(speaker, src) <= GLOB.world_view_size)
+		speaker.cast_tts(src, message) // SS220 ADDITION
 	// BANDAMARINES EDIT END
 
 	to_chat(src, "<span class='game say'><span class='name'>[comm_paygrade][speaker_name]</span>[alt_name] [track][ru_say_verb(verb)], <span class='message'><span class='[style]'>\"[message]\"</span></span></span>")

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -61,7 +61,7 @@
 	// BANDAMARINES EDIT START
 	if(speaker_name == speaker.name)
 		speaker_name = speaker.declent_ru(NOMINATIVE)
-	if(client && speaker.z == z && get_dist(speaker, src) <= GLOB.world_view_size)
+	if(speaker.z == z && get_dist(speaker, src) <= GLOB.world_view_size)
 		speaker.cast_tts(src, message)
 	// BANDAMARINES EDIT END
 

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -62,7 +62,7 @@
 	if(speaker_name == speaker.name)
 		speaker_name = speaker.declent_ru(NOMINATIVE)
 	if(client && speaker.z == z && get_dist(speaker, src) <= GLOB.world_view_size)
-		speaker.cast_tts(src, message) // SS220 ADDITION
+		speaker.cast_tts(src, message)
 	// BANDAMARINES EDIT END
 
 	to_chat(src, "<span class='game say'><span class='name'>[comm_paygrade][speaker_name]</span>[alt_name] [track][ru_say_verb(verb)], <span class='message'><span class='[style]'>\"[message]\"</span></span></span>")


### PR DESCRIPTION
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->
## Что этот PR делает
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Выносит ТТС из-под проверки GhostEars, тем самым убирая привязку ТТС от этого префа.

## Changelog

:cl:
add: Теперь не нужны GhostEars для ТТС с гостоты
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Обзор от Sourcery

Улучшения:
- Запуск преобразования текста в речь для призрачного чата исключительно на основе близости и z-уровня, игнорируя настройку `toggles_chat` в `GhostEars`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Run text-to-speech for ghost chat solely on proximity and z-level, ignoring the GhostEars toggles_chat setting

</details>