### PR TITLE
[ONLY TM] Новая опция для администраторов, позволяющая удалять бездумных мобов во время появления EPT при создании мобов.

### DIFF
--- a/code/datums/emergency_calls/custom.dm
+++ b/code/datums/emergency_calls/custom.dm
@@ -33,8 +33,27 @@
 
 	return
 
-/datum/emergency_call/custom/spawn_candidates(announce, override_spawn_loc)
+/datum/emergency_call/custom/spawn_candidates(announce, override_spawn_loc, delete_mindless_mobs = FALSE)
 	. = ..()
+	if(delete_mindless_mobs)
+		delete_mindless_mobs()
+	else
+		offer_mobs_for_ghosts()
+
+/datum/emergency_call/custom/proc/offer_mobs_for_ghosts()
 	if(owner)
 		for(var/mob/living/carbon/human/H in players_to_offer)
 			owner.free_for_ghosts(H)
+
+/datum/emergency_call/custom/proc/delete_mindless_mobs()
+	var/count_mob_deleted = 0
+	for(var/player in players_to_offer)
+		if(!ismob(player))
+			continue
+		var/mob/spawned_mob = player
+		if(spawned_mob.mind)
+			continue
+		qdel(spawned_mob)
+		count_mob_deleted++
+
+	message_admins("After EPT spawn as [name], [count_mob_deleted] out of [mob_max] mindless mobs were removed.")

--- a/code/modules/admin/topic/topic_events.dm
+++ b/code/modules/admin/topic/topic_events.dm
@@ -317,6 +317,8 @@
 			spawned_human.ckey = owner.ckey
 
 		if (offer_as_ert)
+			var/time_to_decide = 15 SECONDS
+
 			var/datum/emergency_call/custom/em_call = new()
 			var/name = input(usr, "Please name your ERT", "ERT Name", "Admin spawned humans")
 			em_call.name = name
@@ -325,16 +327,21 @@
 			em_call.owner = owner
 
 			var/quiet_launch = TRUE
-			var/ql_prompt = tgui_alert(usr, "Would you like to broadcast the beacon launch? This will reveal the distress beacon to all players.", "Announce distress beacon?", list("Yes", "No"), 20 SECONDS)
+			var/ql_prompt = tgui_alert(usr, "Would you like to broadcast the beacon launch? This will reveal the distress beacon to all players.", "Announce distress beacon?", list("Yes", "No"), time_to_decide)
 			if(ql_prompt == "Yes")
 				quiet_launch = FALSE
 
 			var/announce_receipt = FALSE
-			var/ar_prompt = tgui_alert(usr, "Would you like to announce the beacon received message? This will reveal the distress beacon to all players.", "Announce beacon received?", list("Yes", "No"), 20 SECONDS)
+			var/ar_prompt = tgui_alert(usr, "Would you like to announce the beacon received message? This will reveal the distress beacon to all players.", "Announce beacon received?", list("Yes", "No"), time_to_decide)
 			if(ar_prompt == "Yes")
 				announce_receipt = TRUE
 
-			em_call.activate(quiet_launch, announce_receipt)
+			var/delete_midless_mobs = FALSE
+			var/del_prompt = tgui_alert(usr, "Would you like to delete mindless mobs? This will remove all mobs that did not get mind upon spawn. If not, the mobs will be offered to ghosts.", "Delete mindless mobs?", list("Yes", "No"), time_to_decide)
+			if(del_prompt == "Yes")
+				delete_midless_mobs = TRUE
+
+			em_call.activate(quiet_launch, announce_receipt, delete_midless_mobs)
 
 		message_admins("[key_name_admin(usr)] created [humans_to_spawn] humans as [job_name] at [get_area(initial_spot)]")
 
@@ -413,6 +420,8 @@
 			X.ckey = owner.ckey
 
 		if(offer_as_ert)
+			var/time_to_decide = 15 SECONDS
+
 			var/datum/emergency_call/custom/em_call = new()
 			var/name = input(usr, "Please name your ERT", "ERT Name", "Admin spawned xenos")
 			em_call.name = name
@@ -421,15 +430,20 @@
 			em_call.owner = owner
 
 			var/quiet_launch = TRUE
-			var/ql_prompt = tgui_alert(usr, "Would you like to broadcast the beacon launch? This will reveal the distress beacon to all players.", "Announce distress beacon?", list("Yes", "No"), 20 SECONDS)
+			var/ql_prompt = tgui_alert(usr, "Would you like to broadcast the beacon launch? This will reveal the distress beacon to all players.", "Announce distress beacon?", list("Yes", "No"), time_to_decide)
 			if(ql_prompt == "Yes")
 				quiet_launch = FALSE
 
 			var/announce_receipt = FALSE
-			var/ar_prompt = tgui_alert(usr, "Would you like to announce the beacon received message? This will reveal the distress beacon to all players.", "Announce beacon received?", list("Yes", "No"), 20 SECONDS)
+			var/ar_prompt = tgui_alert(usr, "Would you like to announce the beacon received message? This will reveal the distress beacon to all players.", "Announce beacon received?", list("Yes", "No"), time_to_decide)
 			if(ar_prompt == "Yes")
 				announce_receipt = TRUE
 
-			em_call.activate(quiet_launch, announce_receipt)
+			var/delete_midless_mobs = FALSE
+			var/del_prompt = tgui_alert(usr, "Would you like to delete mindless mobs? This will remove all mobs that did not get mind upon spawn. If not, the mobs will be offered to ghosts.", "Delete mindless mobs?", list("Yes", "No"), time_to_decide)
+			if(del_prompt == "Yes")
+				delete_midless_mobs = TRUE
+
+			em_call.activate(quiet_launch, announce_receipt, delete_midless_mobs)
 
 		message_admins("[key_name_admin(usr)] created [xenos_to_spawn] xenos as [xeno_caste] at [get_area(initial_spot)]")


### PR DESCRIPTION
# О чем ПР:
Фича для педалей
ПР закинут на ОФФы, убрать с ТМа при мерже:
https://github.com/cmss13-devs/cmss13/pull/9402

Теперь администратор может выбирать, удалять ли «бездумных мобов» после завершения создания пользовательского EPT.

# Зачем это?

Например, когда они используют «Создать людей/ксено» как «ERT». Теперь им будет предложена эта опция.

# Тестирование
![image](https://github.com/user-attachments/assets/8f3185cf-a143-4459-99ce-5de9d1000724)

# Changelog
:cl:
add: Опция для администратора по удалению бездумных мобов при создании EPT.
refactor: Рефакторинг кода для ожидания выбора администратора во время создания EPT.
/:cl: