### PR TITLE
Добавлена проверка на сломанные руки при установке и стрельбе пулемета.

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1756,3 +1756,14 @@ GLOBAL_LIST_INIT(duplicate_forbidden_vars,list(
 		return TRUE
 
 	return FALSE
+
+/proc/has_broken_hands(mob/living/carbon/human/H)
+	if(!istype(H))
+		return FALSE
+	var/obj/limb/l_arm = H.get_limb("l_arm")
+	var/obj/limb/r_arm = H.get_limb("r_arm")
+	var/obj/limb/l_hand = H.get_limb("l_hand")
+	var/obj/limb/r_hand = H.get_limb("r_hand")
+	if(l_arm.is_broken() || r_arm.is_broken() || l_hand.is_broken() || r_hand.is_broken())
+		return TRUE
+	return FALSE

--- a/code/modules/cm_marines/m2c.dm
+++ b/code/modules/cm_marines/m2c.dm
@@ -148,6 +148,11 @@
 	if(!do_after(user, M2C_SETUP_TIME, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD))
 		return
 
+	var/mob/living/carbon/human/H = user
+		if(has_broken_hands(H))
+			to_chat(H, SPAN_WARNING("It takes you longer to set up the machine gun with your injury."))
+			sleep(M2C_SETUP_TIME * 2)
+
 	if(!check_can_setup(user, rotate_check, OT, ACR))
 		return
 
@@ -406,6 +411,14 @@
 // AUTOMATIC FIRING
 
 /obj/structure/machinery/m56d_hmg/auto/try_fire()
+	if(operator.l_hand || operator.r_hand)
+		to_chat(operator, SPAN_WARNING("Your hands need to be free to fire [src]!"))
+		return
+	var/mob/living/carbon/human/H = operator
+	if(has_broken_hands(H))
+			to_chat(H, SPAN_WARNING("You can't operate the machine gun with a broken hand or wrist!"))
+			return
+
 	if(fire_stopper)
 		return
 

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -347,6 +347,10 @@
 			return
 		to_chat(user, "You begin mounting [MG]...")
 		if(do_after(user, 30 * user.get_skill_duration_multiplier(SKILL_ENGINEER), INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_BUILD) && !gun_mounted && anchored)
+			var/mob/living/carbon/human/H = user
+			if(has_broken_hands(H))
+					to_chat(H, SPAN_WARNING("It takes you longer to set up the machine gun with your injury."))
+					sleep(30)
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 25, 1)
 			user.visible_message(SPAN_NOTICE("[user] installs [MG] into place."),SPAN_NOTICE("You install [MG] into place."))
 			gun_mounted = 1
@@ -825,6 +829,11 @@
 	if(operator.l_hand || operator.r_hand)
 		to_chat(operator, SPAN_WARNING("Your hands need to be free to fire [src]!"))
 		return
+
+	var/mob/living/carbon/human/H = operator
+	if(has_broken_hands(H))
+			to_chat(H, SPAN_WARNING("You can't operate the machine gun with a broken hand or wrist!"))
+			return
 
 	return fire_shot()
 


### PR DESCRIPTION
## Что этот PR делает
Добавлена проверка на сломанные руки при установке(время увеличивается) и стрельбе пулемета.
Также теперь из m2c стрелять можно только двумя свободными руками.
## Почему это хорошо для игры
Пулеметы требуют использования двух рук, и логично, что если одна из них сломана, то стрелять не получится.
## Изображения изменений
## Тестирование
Протестировано локально, стрельба и установка без перелома и с переломом.
## Changelog

:cl:
add: Добавлена проверка на сломанные руки при установке и стрельбе пулемета
/:cl:
