### PR TITLE
Фикс поиска по блэкмаркет предметам в консоли карго

### DIFF
--- a/tgui/packages/tgui/interfaces/SupplyComputer.tsx
+++ b/tgui/packages/tgui/interfaces/SupplyComputer.tsx
@@ -785,11 +785,12 @@ const RenderCategory = (props: {
     ? categories_to_objects[category]
     : all_items.filter((pack: Pack) => {
         return (
-          pack.name.toLowerCase().includes(lowerCaseCategory) ||
-          pack.english_name.toLowerCase().includes(lowerCaseCategory) ||
-          pack.category.toLowerCase().includes(lowerCaseCategory) ||
-          (pack.english_category &&
-            pack.english_category.toLowerCase().includes(lowerCaseCategory))
+          !pack.dollar_cost &&
+          (pack.name.toLowerCase().includes(lowerCaseCategory) ||
+            pack.english_name.toLowerCase().includes(lowerCaseCategory) ||
+            pack.category.toLowerCase().includes(lowerCaseCategory) ||
+            (pack.english_category &&
+              pack.english_category.toLowerCase().includes(lowerCaseCategory)))
         );
       });
 


### PR DESCRIPTION
## Что этот PR делает

Фикс возможности найти блэкмаркет штуки через поиск в консоли карго без её взлома

## Почему это хорошо для игры

Better UX

## Тестирование

<details>
<summary>Скриншоты и видео</summary>

Без фикса

<img width="1045" height="696" alt="image" src="https://github.com/user-attachments/assets/899727ce-3e1b-4028-bda9-d617bf108212" />

С фиксом

<img width="1052" height="698" alt="image" src="https://github.com/user-attachments/assets/8cb9523c-3dcf-43f8-af95-805b99509438" />

</details>

## Changelog

:cl:
fix: фикс поиска консоли карко по доступным предметам без её взлома
/:cl: