### PR TITLE
Изменение ношения сабли КО

### DIFF
--- a/code/game/objects/items/storage/large_holster.dm
+++ b/code/game/objects/items/storage/large_holster.dm
@@ -178,7 +178,7 @@
 		WEAR_R_HAND = 'icons/mob/humans/onmob/inhands/clothing/belts_righthand.dmi'
 	)
 	force = 12
-	flags_equip_slot = SLOT_WAIST|SLOT_BACK|SLOT_SUIT_STORE
+	flags_equip_slot = SLOT_WAIST|SLOT_BACK|SLOT_SUIT_STORE    // SS220 EDIT
 	can_hold = list(/obj/item/weapon/sword/ceremonial)
 
 /obj/item/storage/large_holster/ceremonial_sword/full/fill_preset_inventory()


### PR DESCRIPTION

## Что этот PR делает
Позволяет носить церемониальный меч КО в слотах спины и рюкзака, без верхней одежды (только с униформой)
Меч используется как дрип, аналоги оружия в виде трости/телескопички не требует ношения брони -> позволим меч носить там, где удобно

Одобрено ответственным за ВЛ КО
## Почему это хорошо для игры
QoL, больше вариантов дрипа
## Изображения изменений
![Снимок](https://github.com/user-attachments/assets/cde32ef3-e22d-4205-b295-7c48a421b648)

## Тестирование
Локалка
## Changelog

:cl:
qol: Саблю ко можно надеть не только в пояс
/:cl:
