### PR TITLE
Большие мобы могут игнорировать толкания в харме от обычных мобов, используя help-интент.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -387,7 +387,8 @@
 		else if((living_mob.is_mob_restrained() || living_mob.a_intent == INTENT_HELP) && (is_mob_restrained() || a_intent == INTENT_HELP))
 			mob_swap = 1
 		// Big mobs (ex.: T3 xeno) can ignore pushes from smaller creatures using the help intent
-		else if(a_intent == INTENT_HELP && mob_size >= MOB_SIZE_BIG && living_mob.mob_size < MOB_SIZE_BIG)
+		else if(!ishuman(living_mob) && !isyautja(living_mob) && ( // But not with humans and jautja
+				a_intent == INTENT_HELP && mob_size >= MOB_SIZE_BIG && living_mob.mob_size < MOB_SIZE_BIG))
 			mob_swap = 1
 		if(mob_swap)
 			//switch our position with L


### PR DESCRIPTION

## Что этот PR делает
Большие ксеноморфы могут выйти из бодиблока, используя HELP интент.

Также было закинуто на ОФФы:
https://github.com/cmss13-devs/cmss13/pull/11045
## Почему это хорошо для игры

PR против нелепых ситуаций, когда 10-тонный ксеноморф блокируется 100-килограммовым морпехом.
Теперь крупный ксеноморф в HELP интенте, может пройти сквозь маленького человечка.
В то же время мы сохраняем возможность крупным ксеноморфам отталкивать в харм-интенте.
## Изображения изменений
https://github.com/user-attachments/assets/4ac39a24-d77a-48a2-9cb5-b3c149bfae50
## Тестирование
Да.
## Changelog

:cl:
balance: Большие мобы (например, большие ксеноморфы T2 или T3) теперь могут игнорировать толкания в харме от обычных мобов, используя help-интент.
/:cl:
