### PR TITLE
Minimum players requirement decrease for some maps

### DIFF
--- a/map_config/maps.txt
+++ b/map_config/maps.txt
@@ -24,7 +24,7 @@ map prison_station_fop
 endmap
 
 map fiorina_sciannex
-	minplayers 130
+	minplayers 100
 endmap
 
 map corsat
@@ -34,7 +34,7 @@ map corsat
 endmap
 
 map desert_dam
-	minplayers 130
+	minplayers 110
 endmap
 
 map ice_colony_v2
@@ -50,14 +50,14 @@ map kutjevo
 endmap
 
 map sorokyne_strata
-	minplayers 110
+	minplayers 90
 endmap
 
 map lv522_chances_claim
 endmap
 
 map lv759_hybrisa_prospera
-	minplayers 130
+	minplayers 110
 endmap
 
 map new_varadero


### PR DESCRIPTION

## Что этот PR делает
Понижает требуемое количество игроков для некоторых карт.

Сорокина 110 -> 90
Фиорина 130 -> 100
Дамба 130 -> 110
Гибриза 130 -> 110

## Почему это хорошо для игры
Повышает разнообразие в картах, особенно для нынешних хайпоп раундов.

## Изображения изменений
## Тестирование

Проверил на локальном сервере
## Changelog

:cl:
config:  Требуемое количество игроков для некоторых карт было немного снижено
/:cl:
