### PR TITLE
Исправление бага с работой сварочных очков

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -129,14 +129,14 @@
 
 /obj/item/clothing/glasses/dropped(mob/living/carbon/human/user)
 	var/was_active = active
-	if(istype(user) && src == user.glasses)
+	if(src == user.glasses)
 		if(hud_type && active)
 			var/datum/mob_hud/H = GLOB.huds[hud_type]
 			H.remove_hud_from(user, src)
 		user.glasses = null
 		user.update_inv_glasses()
 	user.update_sight()
-	if(was_active && ishuman(user))
+	if(was_active)
 		user.update_tint()
 	return ..()
 


### PR DESCRIPTION

## Что этот PR делает
Исправление бага с работой сварочных очков. Теперь при снятии очков зрение нормализуется.
## Почему это хорошо для игры
## Изображения изменений
## Тестирование
## Changelog

:cl:
fix: Исправление бага с работой сварочных очков. Теперь при снятии очков зрение нормализуется.
/:cl:
