### PR TITLE
Фикс шрифта приказов от нового навыка лидерства 

### DIFF
--- a/code/__DEFINES/__game.dm
+++ b/code/__DEFINES/__game.dm
@@ -585,7 +585,7 @@
 /// Disables loading Techwebs and additional Z-Levels
 #define PERF_TOGGLE_TECHWEBS (1<<4)
 
-/// Maptext styles // SS220 EDIT - font change langchat_smaller_bolded 7 to 6px
+/// Maptext styles
 #define MAP_STYLESHEET "\
 img.icon { width: auto; height: auto } \
 .center { text-align: center; } \


### PR DESCRIPTION

## Что этот PR делает

Изменяет шрифт "командирского ора" с 7px на 6px, чтобы он нормально отображался с ру шрифтами без мыла
пс: комент запихнул куда смог, если не нужен уберу 

## Почему это хорошо для игры

Нет мыла над куклами - хорошо

## Изображения изменений

ДО (наверное, на локалке до фикса не смотрел) :                                  

<img width="323" height="267" alt="image" src="https://github.com/user-attachments/assets/76bf48f8-857b-4d0e-9268-9eaa7e1216c0" />


ПОСЛЕ: 

<img width="525" height="350" alt="image" src="https://github.com/user-attachments/assets/29ad0333-0716-43c5-bb99-a1fc79a02d56" />

## Тестирование

целый запуск локалки 1 раз

## Changelog

:cl:
fix: Громкий чат с навыком командования теперь не мыльный
/:cl:
