### PR TITLE
Фикс шрифта оповещения отрядов

### DIFF
--- a/code/game/jobs/job/marine/squads.dm
+++ b/code/game/jobs/job/marine/squads.dm
@@ -465,7 +465,7 @@
 			if(squad_leader in targets_to_garble)
 				squad_leader.play_screen_text("<span class='langchat_notification' style=text-align:center valign='top'><u>[title_text]</u></span><br>[garbled_text]", /atom/movable/screen/text/screen_text/command_order, message_color) // SS220 EDIT: font
 			else
-				squad_leader.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>[title_text]</u></span><br>[text]", /atom/movable/screen/text/screen_text/command_order, message_color)
+				squad_leader.play_screen_text("<span class='langchat' style=font-size:12pt;text-align:center valign='top'><u>[title_text]</u></span><br>[text]", /atom/movable/screen/text/screen_text/command_order, message_color)
 		return
 
 	for(var/mob/living/carbon/human/marine in marines_list)
@@ -474,7 +474,7 @@
 			if(marine in targets_to_garble)
 				marine.play_screen_text("<span class='langchat_notification' style=text-align:center valign='top'><u>[title_text]</u></span><br>[garbled_text]", /atom/movable/screen/text/screen_text/command_order, message_color)
 			else
-				marine.play_screen_text("<span class='langchat' style=font-size:16pt;text-align:center valign='top'><u>[title_text]</u></span><br>[text]", /atom/movable/screen/text/screen_text/command_order, message_color) // SS220 EDIT: font
+				marine.play_screen_text("<span class='langchat' style=font-size:12pt;text-align:center valign='top'><u>[title_text]</u></span><br>[text]", /atom/movable/screen/text/screen_text/command_order, message_color) // SS220 EDIT: font
 
 /// Displays a message to the squad members in chat
 /datum/squad/proc/send_message(text="", transmitter=null, only_leader=FALSE, list/targets_to_garble=null, garbled_text="")


### PR DESCRIPTION
## Что этот PR делает

Чинит шрифт оповещения отрядов

## Почему это хорошо для игры

да

## Изображения изменений

Было:

<img width="912" height="224" alt="image" src="https://github.com/user-attachments/assets/34949e29-caa2-4e61-a4aa-20894efe8eea" />

Стало:

<img width="867" height="134" alt="image" src="https://github.com/user-attachments/assets/b1577b44-cdee-4c5b-a066-2ef8171186b1" />

<img width="1312" height="181" alt="image" src="https://github.com/user-attachments/assets/015bb5a7-4c7d-4b41-a9f4-7e6dd542fbe7" />

## Тестирование

Да

## Changelog

:cl:
fix: Исправлен шрифт оповещения отрядов
/:cl:
