### PR TITLE
Hotfix - Motorbike grab

### DIFF
--- a/modular/vehicles/code/motorbike/bike/motorbike_movement.dm
+++ b/modular/vehicles/code/motorbike/bike/motorbike_movement.dm
@@ -167,6 +167,6 @@
 /obj/vehicle/motorbike/proc/check_pulling()
 	if(pulledby == null)
 		return
-	if(get_dist(src, pulledby) > 2)
+	if(get_dist(src, pulledby) >= 2)
 		pulledby.stop_pulling()
 


### PR DESCRIPTION
Больше нельзя тащить мотоцикл через пол карты. Захват сбрасывается если дистанция между мотоциклом и куклой >= 2 клеток.

Fixes #490

:cl:
fix: Починен захват мотоцикла
/:cl:

