### PR TITLE
tyrargo rift min players map config

### DIFF
--- a/map_config/maps.txt
+++ b/map_config/maps.txt
@@ -65,3 +65,7 @@ endmap
 
 map whiskey_outpost_v2
 endmap
+
+map tyrargo_rift
+    minplayers 110
+endmap


### PR DESCRIPTION

## Что этот PR делает
Настраиваем минимальное число игроков для карты
## Почему это хорошо для игры
## Изображения изменений
## Тестирование
## Changelog

:cl:
mapadd: tyrargo rift min players map config
/:cl:
