### PR TITLE
I killed ДУЛЬНЫЕ УСТРОЙСТВА (fix)

### DIFF
--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -378,7 +378,7 @@
 
 /obj/structure/machinery/cm_vending/sorted/attachments/squad/populate_product_list(scale)
 	listed_products = list(
-		list("ДУЛЬНЫЕ УСТРОЙСТВА", -1, null, null),
+		list("ДУЛЬНЫЕ УСТРОЙСТВА", -1, null, null),	//SS220 EDIT TRANSLATION
 		// list("Barrel Charger", 0.75, /obj/item/attachable/heavy_barrel, VENDOR_ITEM_REGULAR), // SS220 EDIT - Balance attachments
 		list("Extended Recoil Compensator", 2.5, /obj/item/attachable/extended_barrel/vented, VENDOR_ITEM_REGULAR),
 		list("Extended Barrel", 2.5, /obj/item/attachable/extended_barrel, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_prep.dm
@@ -378,7 +378,7 @@
 
 /obj/structure/machinery/cm_vending/sorted/attachments/squad/populate_product_list(scale)
 	listed_products = list(
-		list("BARREL", -1, null, null),
+		list("ДУЛЬНЫЕ УСТРОЙСТВА", -1, null, null),
 		// list("Barrel Charger", 0.75, /obj/item/attachable/heavy_barrel, VENDOR_ITEM_REGULAR), // SS220 EDIT - Balance attachments
 		list("Extended Recoil Compensator", 2.5, /obj/item/attachable/extended_barrel/vented, VENDOR_ITEM_REGULAR),
 		list("Extended Barrel", 2.5, /obj/item/attachable/extended_barrel, VENDOR_ITEM_REGULAR),

--- a/modular/translations/code/translation_data/ru_names/cm13_decor.toml
+++ b/modular/translations/code/translation_data/ru_names/cm13_decor.toml
@@ -250,6 +250,15 @@ instrumental = "столом"
 prepositional = "столе"
 gender = "male"
 
+["barrel"]
+nominative = "бочка"
+genitive = "бочки"
+dative = "бочке"
+accusative = "бочку"
+instrumental = "бочкой"
+prepositional = "бочке"
+gender = "female"
+
 ["red barrel"]
 nominative = "красная бочка"
 genitive = "красной бочки"

--- a/modular/translations/code/translation_data/ru_names/cm13_vendors.toml
+++ b/modular/translations/code/translation_data/ru_names/cm13_vendors.toml
@@ -318,10 +318,6 @@ tags = [ "nominative_only", "cm13",]
 nominative = "СТАЦИОНАРНЫЕ СИСТЕМЫ (ВОЗЬМИТЕ 1)"
 tags = [ "nominative_only", "cm13",]
 
-[barrel]
-nominative = "ДУЛЬНЫЕ УСТРОЙСТВА"
-tags = [ "nominative_only", "cm13",]
-
 [rail]
 nominative = "МОДУЛИ ДЛЯ ВЕРХНЕЙ ПЛАНКИ"
 tags = [ "nominative_only", "cm13",]


### PR DESCRIPTION
## Что этот PR делает
Fixes #596
Добавляет перевод для ИМЕННО бочки - раньше она переводилась, как ДУЛЬНЫЕ УСТРОЙСТВА (на оружие).

## Почему это хорошо для игры
END OF ДУЛЬНЫЕ УСТРОЙСТВА ERA

## Изображения изменений
<img width="1067" height="114" alt="image" src="https://github.com/user-attachments/assets/3f272fb2-93ba-427d-8be6-35cb3f5a1f14" />

## Тестирование
Локалка

## Changelog
:cl: NT
fix: Исправлен недочет в переводе
/:cl:
