### PR TITLE
Fax responders timelocks decrease

### DIFF
--- a/code/game/jobs/job/special/responders.dm
+++ b/code/game/jobs/job/special/responders.dm
@@ -20,8 +20,8 @@
 	gear_preset = /datum/equipment_preset/fax_responder/uscm
 
 AddTimelock(/datum/job/fax_responder/uscm_hc, list(
-	JOB_POLICE_ROLES = 25 HOURS,
-	JOB_COMMAND_ROLES = 75 HOURS,
+	JOB_POLICE_ROLES = 5 HOURS,
+	JOB_COMMAND_ROLES = 15 HOURS,
 ))
 
 /datum/job/fax_responder/uscm_pvst
@@ -29,8 +29,8 @@ AddTimelock(/datum/job/fax_responder/uscm_hc, list(
 	gear_preset = /datum/equipment_preset/fax_responder/uscm/provost
 
 AddTimelock(/datum/job/fax_responder/uscm_pvst, list(
-	JOB_POLICE_ROLES = 75 HOURS,
-	JOB_COMMAND_ROLES = 75 HOURS,
+	JOB_POLICE_ROLES = 15 HOURS,
+	JOB_COMMAND_ROLES = 15 HOURS,
 ))
 
 /datum/job/fax_responder/wy
@@ -38,7 +38,7 @@ AddTimelock(/datum/job/fax_responder/uscm_pvst, list(
 	gear_preset = /datum/equipment_preset/fax_responder/wey_yu
 
 AddTimelock(/datum/job/fax_responder/wy, list(
-	JOB_CORPORATE_ROLES = 75 HOURS,
+	JOB_CORPORATE_ROLES = 15 HOURS,
 ))
 
 /datum/job/fax_responder/upp
@@ -46,7 +46,7 @@ AddTimelock(/datum/job/fax_responder/wy, list(
 	gear_preset = /datum/equipment_preset/fax_responder/upp
 
 AddTimelock(/datum/job/fax_responder/upp, list(
-	JOB_COMMAND_ROLES = 75 HOURS,
+	JOB_COMMAND_ROLES = 15 HOURS,
 ))
 
 /datum/job/fax_responder/twe
@@ -54,7 +54,7 @@ AddTimelock(/datum/job/fax_responder/upp, list(
 	gear_preset = /datum/equipment_preset/fax_responder/twe
 
 AddTimelock(/datum/job/fax_responder/twe, list(
-	JOB_COMMAND_ROLES = 75 HOURS,
+	JOB_COMMAND_ROLES = 15 HOURS,
 ))
 
 /datum/job/fax_responder/clf
@@ -62,7 +62,7 @@ AddTimelock(/datum/job/fax_responder/twe, list(
 	gear_preset = /datum/equipment_preset/fax_responder/clf
 
 AddTimelock(/datum/job/fax_responder/clf, list(
-	JOB_COMMAND_ROLES = 75 HOURS,
+	JOB_COMMAND_ROLES = 15 HOURS,
 ))
 
 /datum/job/fax_responder/cmb
@@ -70,8 +70,8 @@ AddTimelock(/datum/job/fax_responder/clf, list(
 	gear_preset = /datum/equipment_preset/fax_responder/cmb
 
 AddTimelock(/datum/job/fax_responder/cmb, list(
-	JOB_POLICE_ROLES = 75 HOURS,
-	JOB_COMMAND_ROLES = 25 HOURS,
+	JOB_POLICE_ROLES = 15 HOURS,
+	JOB_COMMAND_ROLES = 15 HOURS,
 ))
 
 /datum/job/fax_responder/press
@@ -79,5 +79,5 @@ AddTimelock(/datum/job/fax_responder/cmb, list(
 	gear_preset = /datum/equipment_preset/fax_responder/press
 
 AddTimelock(/datum/job/fax_responder/press, list(
-	JOB_CIVIL_ROLES = 25 HOURS,
+	JOB_CIVIL_ROLES = 15 HOURS,
 ))

--- a/code/game/jobs/job/special/responders.dm
+++ b/code/game/jobs/job/special/responders.dm
@@ -20,8 +20,8 @@
 	gear_preset = /datum/equipment_preset/fax_responder/uscm
 
 AddTimelock(/datum/job/fax_responder/uscm_hc, list(
-	JOB_POLICE_ROLES = 5 HOURS,
-	JOB_COMMAND_ROLES = 15 HOURS,
+	JOB_POLICE_ROLES = 5 HOURS,						//SS220 EDIT: balance
+	JOB_COMMAND_ROLES = 15 HOURS,					//SS220 EDIT: balance
 ))
 
 /datum/job/fax_responder/uscm_pvst
@@ -29,8 +29,8 @@ AddTimelock(/datum/job/fax_responder/uscm_hc, list(
 	gear_preset = /datum/equipment_preset/fax_responder/uscm/provost
 
 AddTimelock(/datum/job/fax_responder/uscm_pvst, list(
-	JOB_POLICE_ROLES = 15 HOURS,
-	JOB_COMMAND_ROLES = 15 HOURS,
+	JOB_POLICE_ROLES = 15 HOURS,					//SS220 EDIT: balance
+	JOB_COMMAND_ROLES = 15 HOURS,					//SS220 EDIT: balance
 ))
 
 /datum/job/fax_responder/wy
@@ -38,7 +38,7 @@ AddTimelock(/datum/job/fax_responder/uscm_pvst, list(
 	gear_preset = /datum/equipment_preset/fax_responder/wey_yu
 
 AddTimelock(/datum/job/fax_responder/wy, list(
-	JOB_CORPORATE_ROLES = 15 HOURS,
+	JOB_CORPORATE_ROLES = 15 HOURS,					//SS220 EDIT: balance
 ))
 
 /datum/job/fax_responder/upp
@@ -46,7 +46,7 @@ AddTimelock(/datum/job/fax_responder/wy, list(
 	gear_preset = /datum/equipment_preset/fax_responder/upp
 
 AddTimelock(/datum/job/fax_responder/upp, list(
-	JOB_COMMAND_ROLES = 15 HOURS,
+	JOB_COMMAND_ROLES = 15 HOURS,					//SS220 EDIT: balance
 ))
 
 /datum/job/fax_responder/twe
@@ -54,7 +54,7 @@ AddTimelock(/datum/job/fax_responder/upp, list(
 	gear_preset = /datum/equipment_preset/fax_responder/twe
 
 AddTimelock(/datum/job/fax_responder/twe, list(
-	JOB_COMMAND_ROLES = 15 HOURS,
+	JOB_COMMAND_ROLES = 15 HOURS,					//SS220 EDIT: balance
 ))
 
 /datum/job/fax_responder/clf
@@ -62,7 +62,7 @@ AddTimelock(/datum/job/fax_responder/twe, list(
 	gear_preset = /datum/equipment_preset/fax_responder/clf
 
 AddTimelock(/datum/job/fax_responder/clf, list(
-	JOB_COMMAND_ROLES = 15 HOURS,
+	JOB_COMMAND_ROLES = 15 HOURS,					//SS220 EDIT: balance
 ))
 
 /datum/job/fax_responder/cmb
@@ -70,8 +70,8 @@ AddTimelock(/datum/job/fax_responder/clf, list(
 	gear_preset = /datum/equipment_preset/fax_responder/cmb
 
 AddTimelock(/datum/job/fax_responder/cmb, list(
-	JOB_POLICE_ROLES = 15 HOURS,
-	JOB_COMMAND_ROLES = 15 HOURS,
+	JOB_POLICE_ROLES = 15 HOURS,					//SS220 EDIT: balance
+	JOB_COMMAND_ROLES = 15 HOURS,					//SS220 EDIT: balance
 ))
 
 /datum/job/fax_responder/press
@@ -79,5 +79,5 @@ AddTimelock(/datum/job/fax_responder/cmb, list(
 	gear_preset = /datum/equipment_preset/fax_responder/press
 
 AddTimelock(/datum/job/fax_responder/press, list(
-	JOB_CIVIL_ROLES = 15 HOURS,
+	JOB_CIVIL_ROLES = 15 HOURS,						//SS220 EDIT: balance
 ))

--- a/code/game/jobs/job/special/responders.dm
+++ b/code/game/jobs/job/special/responders.dm
@@ -20,8 +20,8 @@
 	gear_preset = /datum/equipment_preset/fax_responder/uscm
 
 AddTimelock(/datum/job/fax_responder/uscm_hc, list(
-	JOB_POLICE_ROLES = 5 HOURS,						//SS220 EDIT: balance
-	JOB_COMMAND_ROLES = 15 HOURS,					//SS220 EDIT: balance
+	JOB_POLICE_ROLES = 5 HOURS,						//SS220 EDIT CHANGE
+	JOB_COMMAND_ROLES = 15 HOURS,					//SS220 EDIT CHANGE
 ))
 
 /datum/job/fax_responder/uscm_pvst
@@ -29,8 +29,8 @@ AddTimelock(/datum/job/fax_responder/uscm_hc, list(
 	gear_preset = /datum/equipment_preset/fax_responder/uscm/provost
 
 AddTimelock(/datum/job/fax_responder/uscm_pvst, list(
-	JOB_POLICE_ROLES = 15 HOURS,					//SS220 EDIT: balance
-	JOB_COMMAND_ROLES = 15 HOURS,					//SS220 EDIT: balance
+	JOB_POLICE_ROLES = 15 HOURS,					//SS220 EDIT CHANGE
+	JOB_COMMAND_ROLES = 15 HOURS,					//SS220 EDIT CHANGE
 ))
 
 /datum/job/fax_responder/wy
@@ -38,7 +38,7 @@ AddTimelock(/datum/job/fax_responder/uscm_pvst, list(
 	gear_preset = /datum/equipment_preset/fax_responder/wey_yu
 
 AddTimelock(/datum/job/fax_responder/wy, list(
-	JOB_CORPORATE_ROLES = 15 HOURS,					//SS220 EDIT: balance
+	JOB_CORPORATE_ROLES = 15 HOURS,					//SS220 EDIT CHANGE
 ))
 
 /datum/job/fax_responder/upp
@@ -46,7 +46,7 @@ AddTimelock(/datum/job/fax_responder/wy, list(
 	gear_preset = /datum/equipment_preset/fax_responder/upp
 
 AddTimelock(/datum/job/fax_responder/upp, list(
-	JOB_COMMAND_ROLES = 15 HOURS,					//SS220 EDIT: balance
+	JOB_COMMAND_ROLES = 15 HOURS,					//SS220 EDIT CHANGE
 ))
 
 /datum/job/fax_responder/twe
@@ -54,7 +54,7 @@ AddTimelock(/datum/job/fax_responder/upp, list(
 	gear_preset = /datum/equipment_preset/fax_responder/twe
 
 AddTimelock(/datum/job/fax_responder/twe, list(
-	JOB_COMMAND_ROLES = 15 HOURS,					//SS220 EDIT: balance
+	JOB_COMMAND_ROLES = 15 HOURS,					//SS220 EDIT CHANGE
 ))
 
 /datum/job/fax_responder/clf
@@ -62,7 +62,7 @@ AddTimelock(/datum/job/fax_responder/twe, list(
 	gear_preset = /datum/equipment_preset/fax_responder/clf
 
 AddTimelock(/datum/job/fax_responder/clf, list(
-	JOB_COMMAND_ROLES = 15 HOURS,					//SS220 EDIT: balance
+	JOB_COMMAND_ROLES = 15 HOURS,					//SS220 EDIT CHANGE
 ))
 
 /datum/job/fax_responder/cmb
@@ -70,8 +70,8 @@ AddTimelock(/datum/job/fax_responder/clf, list(
 	gear_preset = /datum/equipment_preset/fax_responder/cmb
 
 AddTimelock(/datum/job/fax_responder/cmb, list(
-	JOB_POLICE_ROLES = 15 HOURS,					//SS220 EDIT: balance
-	JOB_COMMAND_ROLES = 15 HOURS,					//SS220 EDIT: balance
+	JOB_POLICE_ROLES = 15 HOURS,					//SS220 EDIT CHANGE
+	JOB_COMMAND_ROLES = 15 HOURS,					//SS220 EDIT CHANGE
 ))
 
 /datum/job/fax_responder/press
@@ -79,5 +79,5 @@ AddTimelock(/datum/job/fax_responder/cmb, list(
 	gear_preset = /datum/equipment_preset/fax_responder/press
 
 AddTimelock(/datum/job/fax_responder/press, list(
-	JOB_CIVIL_ROLES = 15 HOURS,						//SS220 EDIT: balance
+	JOB_CIVIL_ROLES = 15 HOURS,						//SS220 EDIT CHANGE
 ))


### PR DESCRIPTION
## Что этот PR делает
Уменьшает таймлоки для подвидов ответчиков на факс до 15 часов максимум. Согласовано с сенатором ВЛа.
Fixes #617 

## Почему это хорошо для игры
Упрощает жизнь начинающим бюрократам и, в следствие, админам

## Тестирование
В своем воображении

## Changelog
:cl: NT
balance: Изменены таймлоки факс-респондеров
/:cl: