### PR TITLE
Вырезание кнопки "форум"

### DIFF
--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -75,11 +75,13 @@ let bigButtons = [
 		command: "wiki",
 		icon: "book"
 	},
+/*
 	{
 		name: "Forum",
 		command: "forum",
 		icon: "envelope"
 	},
+*/
 	{
 		name: "Submit Bug",
 		command: "submit-bug",


### PR DESCRIPTION

## Что этот PR делает

Вырезает кнопку "форум"

## Почему это хорошо для игры

https://github.com/ss220club/BandaMarines/issues/601

## Изображения изменений

<img width="548" height="42" alt="image" src="https://github.com/user-attachments/assets/eb74f702-ec48-4491-84b3-63ec2bfcc042" />

## Тестирование

да

## Changelog
:cl:
del: Удалена лишняя кнопка "форум"
/:cl:
