### PR TITLE
Remove "Show Plasma" button

### DIFF
--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -434,20 +434,7 @@ const XenoList = (props) => {
           </Flex.Item>
         </Flex>
       </Flex.Item>
-      <Flex.Item mb={1}>
-        <Flex align="baseline">
-          <Flex.Item>
-            <Button.Checkbox
-              inline
-              checked={showPlasma}
-              backgroundColor={showPlasma && hive_color}
-              onClick={() => setShowPlasma(!showPlasma)}
-            >
-              Show Plasma
-            </Button.Checkbox>
-          </Flex.Item>
-        </Flex>
-      </Flex.Item>
+      {/* 220 EDIT - DELETE  Show Plasma*/}
       <Flex.Item mb={1}>
         <Flex align="baseline">
           <Flex.Item width="100px">Максимальное здоровье:</Flex.Item>

--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -434,7 +434,6 @@ const XenoList = (props) => {
           </Flex.Item>
         </Flex>
       </Flex.Item>
-      {/* 220 EDIT - DELETE  Show Plasma*/}
       <Flex.Item mb={1}>
         <Flex align="baseline">
           <Flex.Item width="100px">Максимальное здоровье:</Flex.Item>


### PR DESCRIPTION
## Что этот PR делает
Буквально убирает кнопку Show Plasma из меню хайва.
Ишшуй: fix https://github.com/ss220club/BandaMarines/issues/598

## Почему это хорошо для игры
В этом меню изначально две кнопки было, Показать плазму и  Show Plasma, зачем нам две кнопки с одинаковым функционалом?

## Изображения изменений
<img width="475" height="153" alt="Скриншот 30-04-2026 225555" src="https://github.com/user-attachments/assets/de27977d-b286-4e00-b7bf-0ea988d72bc9" />
<img width="428" height="100" alt="Скриншот 30-04-2026 223328" src="https://github.com/user-attachments/assets/d66bc034-0639-4da7-8058-c98ba5dde0d1" />

## Тестирование
Локалка

## Changelog

:cl:
add: Убрана кнопка "Show Plasma" из Hive Status.

/:cl:
