### PR TITLE
View stats only after round end or on extended rounds

### DIFF
--- a/modular/stats_viewer/code/stats_mob.dm
+++ b/modular/stats_viewer/code/stats_mob.dm
@@ -4,6 +4,9 @@
 
 	if(!client)
 		return
+	if(SSticker.current_state != GAME_STATE_FINISHED && !istype(SSticker.mode, /datum/game_mode/extended))
+		to_chat(src, SPAN_WARNING("Раунд всё ещё в процессе!"))
+		return
 	var/datum/round_stats/round_stats = new()
 	round_stats.tgui_interact(src)
 


### PR DESCRIPTION

## Что этот PR делает
Теперь просмотр своей статистики доступен только в конце раунда (или в режиме Extended)

fixes https://github.com/ss220club/BandaMarines/issues/653

## Почему это хорошо для игры
Метагейм в моей гейм

## Changelog
:cl:
add: Теперь просмотр своей статистики доступен только в конце раунда (или в режиме Extended)
/:cl:
