### PR TITLE
[TM ONLY] Oppressor can't abduct through cades

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/oppressor.dm
+++ b/code/modules/mob/living/carbon/xenomorph/strains/castes/praetorian/oppressor.dm
@@ -141,7 +141,7 @@
 			if(istype(structure, /obj/structure/barricade))
 				var/obj/structure/barricade/cade = structure
 				var/cade_facing = cade.dir
-				if(cade_facing == turn(facing, 180))
+				if(cade_facing & turn(facing, 180))
 					blocked = TRUE
 				else if(cade_facing == facing)
 					allow_one_more_step = TRUE


### PR DESCRIPTION

## Что этот PR делает
Опрессор теперь не может хукать через кады под углом.


https://github.com/user-attachments/assets/7a54faba-1db5-4bc0-a10a-5a20028f03a4



## Changelog
:cl:

fix: Опрессор теперь не может хукать через кады под углом.
/:cl:
