### PR TITLE
Xeno Customizations now work with Seethrough Action

### DIFF
--- a/code/__DEFINES/bandamarines/signals.dm
+++ b/code/__DEFINES/bandamarines/signals.dm
@@ -7,7 +7,10 @@
 ///from base of /mob/living/launch_towards(): (launch_metadata)
 #define COMSIG_LIVING_PRE_LAUNCH_TOWARDS "living_pre_launch_towards"
 
+///from base of /datum/component//datum/component/seethrough_mob/trick_mob()
 #define COMSIG_SEETHROUGH_TRICK "seethrough_trick"
 	#define COMPONENT_SEETHROUGH_TRICKED (1<<0)
+
+///from base of /datum/component//datum/component/seethrough_mob/untrick_mob()
 #define COMSIG_SEETHROUGH_UNTRICK "seethrough_untrick"
 	#define COMPONENT_SEETHROUGH_UNTRICKED (1<<0)

--- a/code/__DEFINES/bandamarines/signals.dm
+++ b/code/__DEFINES/bandamarines/signals.dm
@@ -6,3 +6,8 @@
 
 ///from base of /mob/living/launch_towards(): (launch_metadata)
 #define COMSIG_LIVING_PRE_LAUNCH_TOWARDS "living_pre_launch_towards"
+
+#define COMSIG_SEETHROUGH_TRICK "seethrough_trick"
+	#define COMPONENT_SEETHROUGH_TRICKED (1<<0)
+#define COMSIG_SEETHROUGH_UNTRICK "seethrough_untrick"
+	#define COMPONENT_SEETHROUGH_UNTRICKED (1<<0)

--- a/code/modules/mob/living/carbon/xenomorph/seethrough.dm
+++ b/code/modules/mob/living/carbon/xenomorph/seethrough.dm
@@ -47,6 +47,11 @@
 /datum/component/seethrough_mob/proc/trick_mob()
 	SIGNAL_HANDLER
 
+	// BANDAMARINES EDIT START - XENO CUSTOMIZATIONS
+	if(SEND_SIGNAL(parent, COMSIG_SEETHROUGH_TRICK) & COMPONENT_SEETHROUGH_TRICKED)
+		return
+	// BANDAMARINES EDIT END
+
 	var/mob/fool = parent
 
 	render_source_atom.pixel_x = 0
@@ -76,9 +81,13 @@
 
 ///Remove the screen object and make us appear solid to ourselves again
 /datum/component/seethrough_mob/proc/untrick_mob()
+	// BANDAMARINES EDIT START - XENO CUSTOMIZATIONS
+	if(SEND_SIGNAL(parent, COMSIG_SEETHROUGH_UNTRICK) & COMPONENT_SEETHROUGH_UNTRICKED)
+		return
+	// BANDAMARINES EDIT END
 	var/mob/fool = parent
 	animate(trickery_image, alpha = 255, time = animation_time)
-	UnregisterSignal(fool, COMSIG_MOB_LOGOUT)
+	UnregisterSignal(fool, list(COMSIG_MOB_LOGOUT, COMSIG_MOB_GHOSTIZE)) // BANDAMARINES EDIT - XENO CUSTOMIZATIONS
 
 	//after playing the fade-in animation, remove the image and the trick atom
 	addtimer(CALLBACK(src, PROC_REF(clear_image), trickery_image, fool.client), animation_time)

--- a/modular/xeno_customization/code/component.dm
+++ b/modular/xeno_customization/code/component.dm
@@ -5,9 +5,9 @@
 	/// The thing to show
 	var/datum/xeno_customization_option/option
 	/// What the selected option is showing, be it an overlay or full body replacement
-	var/atom/movable/xeno_customization_part/to_show
+	var/atom/movable/to_show
 	/// Is how we subtract parts of an icon, by showing it and applying subtract_filter to an image
-	var/atom/movable/xeno_customization_part/subtract/to_remove
+	var/atom/movable/to_remove
 	/// Our filter that allows to subtract parts of (or an entire) icon
 	var/dm_filter/subtract_filter
 	/// List of players who are ready/already see customization
@@ -323,7 +323,7 @@
 	copy.vis_contents = source.vis_contents.Copy()
 	copy.filters = source.filters
 	copy.layer = source.layer
-	for(var/atom/movable/xeno_customization_part/visible in copy.vis_contents)
+	for(var/atom/movable/visible in copy.vis_contents)
 		visible.plane = SEETHROUGH_PLANE
 	return copy
 
@@ -345,10 +345,6 @@
 
 	parent_xeno.client.images += trickery_image
 	animate(trickery_image, alpha = 100, time = TRICKERY_ANIMATION_TIME)
-	for(var/atom/movable/xeno_customization_part/visible in trickery_image.vis_contents)
-		if(visible.is_subtract)
-			continue
-		animate(visible, alpha = 100, time = TRICKERY_ANIMATION_TIME)
 	RegisterSignal(parent_xeno, list(COMSIG_MOB_LOGOUT, COMSIG_MOB_GHOSTIZE), PROC_REF(untrick_mob))
 
 /atom/movable/xeno_customization_vis_obj/proc/untrick_mob()
@@ -356,10 +352,6 @@
 	. = COMPONENT_SEETHROUGH_UNTRICKED
 
 	animate(trickery_image, alpha = 255, time = TRICKERY_ANIMATION_TIME)
-	for(var/atom/movable/xeno_customization_part/visible in trickery_image.vis_contents)
-		if(visible.is_subtract)
-			continue
-		animate(visible, alpha = 255, time = TRICKERY_ANIMATION_TIME)
 	addtimer(CALLBACK(src, PROC_REF(clear_tricky)), TRICKERY_ANIMATION_TIME)
 
 /atom/movable/xeno_customization_vis_obj/proc/clear_tricky()
@@ -368,11 +360,5 @@
 	parent_xeno.client?.images -= trickery_image
 	QDEL_NULL(trickery_image)
 	UnregisterSignal(parent_xeno, list(COMSIG_MOB_LOGOUT, COMSIG_MOB_GHOSTIZE))
-
-/atom/movable/xeno_customization_part
-	var/is_subtract = FALSE
-
-/atom/movable/xeno_customization_part/subtract
-	is_subtract = TRUE
 
 #undef TRICKERY_ANIMATION_TIME

--- a/modular/xeno_customization/code/component.dm
+++ b/modular/xeno_customization/code/component.dm
@@ -285,6 +285,8 @@
 	/// Seethrough image that the owner sees when Seethrough is active
 	var/image/trickery_image
 
+	var/datum/component/seethrough_mob/seethrough_component
+
 /atom/movable/xeno_customization_vis_obj/Initialize(mapload, ...)
 	. = ..()
 	parent_xeno = loc
@@ -323,13 +325,16 @@
 	copy.vis_contents = source.vis_contents.Copy()
 	copy.filters = source.filters
 	copy.layer = source.layer
-	for(var/atom/movable/visible in copy.vis_contents)
-		visible.plane = SEETHROUGH_PLANE
 	return copy
 
 /atom/movable/xeno_customization_vis_obj/proc/trick_mob()
 	SIGNAL_HANDLER
 	. = COMPONENT_SEETHROUGH_TRICKED
+
+	if(!parent_xeno.client)
+		return
+	if(!seethrough_component)
+		seethrough_component = parent_xeno.GetComponent(/datum/component/seethrough_mob)
 
 	switch(parent_xeno.client.prefs.xeno_customization_visibility)
 		if(XENO_CUSTOMIZATION_SHOW_ALL)
@@ -345,14 +350,24 @@
 
 	parent_xeno.client.images += trickery_image
 	animate(trickery_image, alpha = 100, time = TRICKERY_ANIMATION_TIME)
-	RegisterSignal(parent_xeno, list(COMSIG_MOB_LOGOUT, COMSIG_MOB_GHOSTIZE), PROC_REF(untrick_mob))
+	RegisterSignal(parent_xeno, list(COMSIG_MOB_LOGOUT, COMSIG_MOB_GHOSTIZE), PROC_REF(on_mob_logout))
+	seethrough_component.is_active = TRUE
 
-/atom/movable/xeno_customization_vis_obj/proc/untrick_mob()
+/atom/movable/xeno_customization_vis_obj/proc/untrick_mob(mob/owner, skip_animation)
 	SIGNAL_HANDLER
 	. = COMPONENT_SEETHROUGH_UNTRICKED
 
+	if(skip_animation)
+		clear_tricky()
+		return
+
 	animate(trickery_image, alpha = 255, time = TRICKERY_ANIMATION_TIME)
 	addtimer(CALLBACK(src, PROC_REF(clear_tricky)), TRICKERY_ANIMATION_TIME)
+
+/atom/movable/xeno_customization_vis_obj/proc/on_mob_logout()
+	SIGNAL_HANDLER
+
+	untrick_mob(skip_animation = TRUE)
 
 /atom/movable/xeno_customization_vis_obj/proc/clear_tricky()
 	SIGNAL_HANDLER
@@ -360,5 +375,6 @@
 	parent_xeno.client?.images -= trickery_image
 	QDEL_NULL(trickery_image)
 	UnregisterSignal(parent_xeno, list(COMSIG_MOB_LOGOUT, COMSIG_MOB_GHOSTIZE))
+	seethrough_component.is_active = FALSE
 
 #undef TRICKERY_ANIMATION_TIME

--- a/modular/xeno_customization/code/component.dm
+++ b/modular/xeno_customization/code/component.dm
@@ -22,8 +22,6 @@
 	/// Is customization currently allowed to update? Used for strain check.
 	var/updating = TRUE
 
-	var/image/trickery_image
-
 /datum/component/xeno_customization/Initialize(datum/xeno_customization_option/option, list/mob/override_viewers)
 	if(!isxeno(parent))
 		return COMPONENT_INCOMPATIBLE
@@ -51,16 +49,12 @@
 	RegisterSignal(parent, COMSIG_ALTER_GHOST, PROC_REF(on_ghost))
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_FILTERS, PROC_REF(on_update_filters))
 	RegisterSignal(parent, COMSIG_XENO_STRAIN_ADD, PROC_REF(on_strain_change))
-	RegisterSignal(parent, COMSIG_SEETHROUGH_TRICK, PROC_REF(trick_mob))
-	RegisterSignal(parent, COMSIG_SEETHROUGH_UNTRICK, PROC_REF(untrick_mob))
 
 /datum/component/xeno_customization/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_XENO_UPDATE_ICONS)
 	UnregisterSignal(parent, COMSIG_ALTER_GHOST)
 	UnregisterSignal(parent, COMSIG_ATOM_UPDATE_FILTERS)
 	UnregisterSignal(parent, COMSIG_XENO_STRAIN_ADD)
-	UnregisterSignal(parent, COMSIG_SEETHROUGH_TRICK)
-	UnregisterSignal(parent, COMSIG_SEETHROUGH_UNTRICK)
 
 /datum/component/xeno_customization/Destroy(force, silent)
 	remove_from_everyone_view()
@@ -326,15 +320,13 @@
 	SIGNAL_HANDLER
 	. = COMPONENT_SEETHROUGH_TRICKED
 
-	var/atom/movable/what_trickery
 	switch(parent_xeno.client.prefs.xeno_customization_visibility)
 		if(XENO_CUSTOMIZATION_SHOW_ALL)
-			what_trickery = non_lore_image
+			trickery_image = image(non_lore_image, src)
 		if(XENO_CUSTOMIZATION_SHOW_LORE_FRIENDLY)
-			what_trickery = lore_image
+			trickery_image = image(lore_image, src)
 		else
-			what_trickery = src
-	trickery_image = image(what_trickery, src)
+			trickery_image = image(src, src)
 	trickery_image.override = TRUE
 	trickery_image.plane = SEETHROUGH_PLANE
 	trickery_image.pixel_x = 0
@@ -353,23 +345,5 @@
 /atom/movable/xeno_customization_vis_obj/proc/clear_tricky()
 	parent_xeno.client?.images -= trickery_image
 	QDEL_NULL(trickery_image)
-
-/datum/component/xeno_customization/proc/trick_mob()
-	SIGNAL_HANDLER
-
-	// remove_from_player_view(parent)
-	// animate(trickery_image, alpha = 100, time = TRICKERY_ANIMATION_TIME)
-
-/datum/component/xeno_customization/proc/untrick_mob()
-	SIGNAL_HANDLER
-
-	// animate(trickery_image, alpha = 255, time = TRICKERY_ANIMATION_TIME)
-	// addtimer(CALLBACK(src, PROC_REF(clear_tricky)), TRICKERY_ANIMATION_TIME)
-
-/datum/component/xeno_customization/proc/clear_tricky()
-	// var/mob/user = parent
-	// user.client?.images -= trickery_image
-	// QDEL_NULL(trickery_image)
-	// add_to_player_view(parent)
 
 #undef TRICKERY_ANIMATION_TIME

--- a/modular/xeno_customization/code/component.dm
+++ b/modular/xeno_customization/code/component.dm
@@ -325,13 +325,6 @@
 	copy.layer = source.layer
 	for(var/atom/movable/xeno_customization_part/visible in copy.vis_contents)
 		visible.plane = SEETHROUGH_PLANE
-		if(!visible.is_subtract)
-			continue
-		// visible.alpha = 999
-		// visible.appearance_flags
-		// visible.render_target = "*subtract_filter_[REF(src)]"
-		// var/subtract_filter = filter(type="alpha", render_source = visible.render_target, flags = MASK_INVERSE)
-		// copy.filters += subtract_filter
 	return copy
 
 /atom/movable/xeno_customization_vis_obj/proc/trick_mob()

--- a/modular/xeno_customization/code/component.dm
+++ b/modular/xeno_customization/code/component.dm
@@ -1,3 +1,5 @@
+#define TRICKERY_ANIMATION_TIME 0.5 SECONDS
+
 /datum/component/xeno_customization
 	dupe_mode = COMPONENT_DUPE_ALLOWED
 	/// The thing to show
@@ -19,6 +21,9 @@
 	var/active = TRUE
 	/// Is customization currently allowed to update? Used for strain check.
 	var/updating = TRUE
+
+	/// Seethrough is using the same render_target/source logic as we do, so we must copy the same effect
+	var/seethrough_active = FALSE
 
 /datum/component/xeno_customization/Initialize(datum/xeno_customization_option/option, list/mob/override_viewers)
 	if(!isxeno(parent))
@@ -47,12 +52,16 @@
 	RegisterSignal(parent, COMSIG_ALTER_GHOST, PROC_REF(on_ghost))
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_FILTERS, PROC_REF(on_update_filters))
 	RegisterSignal(parent, COMSIG_XENO_STRAIN_ADD, PROC_REF(on_strain_change))
+	RegisterSignal(parent, COMSIG_SEETHROUGH_TRICK, PROC_REF(trick_mob))
+	RegisterSignal(parent, COMSIG_SEETHROUGH_UNTRICK, PROC_REF(untrick_mob))
 
 /datum/component/xeno_customization/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_XENO_UPDATE_ICONS)
 	UnregisterSignal(parent, COMSIG_ALTER_GHOST)
 	UnregisterSignal(parent, COMSIG_ATOM_UPDATE_FILTERS)
 	UnregisterSignal(parent, COMSIG_XENO_STRAIN_ADD)
+	UnregisterSignal(parent, COMSIG_SEETHROUGH_TRICK)
+	UnregisterSignal(parent, COMSIG_SEETHROUGH_UNTRICK)
 
 /datum/component/xeno_customization/Destroy(force, silent)
 	remove_from_everyone_view()
@@ -160,19 +169,18 @@
 /// Adding images to player's screen
 /datum/component/xeno_customization/proc/check_visibility_pref(mob/user)
 	remove_from_player_view(user)
+	if(user == parent && seethrough_active)
+		return
 	switch(user.client.prefs.xeno_customization_visibility)
 		if(XENO_CUSTOMIZATION_SHOW_ALL)
 			// Only Xenos and Observers can see Non-Lore-Friendly customizations
 			if(!(isxeno(user) || isobserver(user) || isnewplayer(user)))
 				user.client.images |= render_source_atom.lore_image
-				return
-			user.client.images |= render_source_atom.non_lore_image
+			else
+				user.client.images |= render_source_atom.non_lore_image
 
 		if(XENO_CUSTOMIZATION_SHOW_LORE_FRIENDLY)
 			user.client.images |= render_source_atom.lore_image
-
-		if(XENO_CUSTOMIZATION_SHOW_NONE)
-			return
 
 /datum/component/xeno_customization/proc/on_update_filters(mob/owner)
 	SIGNAL_HANDLER
@@ -282,6 +290,8 @@
 	var/image/lore_image
 	/// The mob's original render_target value, when all components are deleted
 	var/initial_render_target_value
+	/// Seethrough image that the owner sees when Seethrough is active
+	var/image/trickery_image
 
 /atom/movable/xeno_customization_vis_obj/Initialize(mapload, ...)
 	. = ..()
@@ -307,4 +317,47 @@
 	parent_xeno.vis_contents -= src
 	QDEL_NULL(non_lore_image)
 	QDEL_NULL(lore_image)
+	QDEL_NULL(trickery_image)
 	. = ..()
+
+/datum/component/xeno_customization/proc/trick_mob()
+	SIGNAL_HANDLER
+
+	. = COMPONENT_SEETHROUGH_TRICKED
+	var/mob/user = parent
+	seethrough_active = TRUE
+	var/pref = user.client.prefs.xeno_customization_visibility
+	var/atom/movable/what_trickery
+	switch(pref)
+		if(XENO_CUSTOMIZATION_SHOW_ALL)
+			what_trickery = render_source_atom.non_lore_image
+		if(XENO_CUSTOMIZATION_SHOW_LORE_FRIENDLY)
+			what_trickery = render_source_atom.lore_image
+		else
+			what_trickery = render_source_atom
+	render_source_atom.trickery_image = new(what_trickery)
+	render_source_atom.trickery_image.loc = render_source_atom
+	render_source_atom.trickery_image.override = TRUE
+	render_source_atom.trickery_image.plane = SEETHROUGH_PLANE
+
+	user.client.images += render_source_atom.trickery_image
+
+	animate(render_source_atom.trickery_image, alpha = 100, time = TRICKERY_ANIMATION_TIME)
+	return .
+
+/datum/component/xeno_customization/proc/untrick_mob()
+	SIGNAL_HANDLER
+
+	. = COMPONENT_SEETHROUGH_UNTRICKED
+	seethrough_active = FALSE
+	if(!render_source_atom.trickery_image)
+		return .
+	animate(render_source_atom.trickery_image, alpha = 255, time = TRICKERY_ANIMATION_TIME)
+	addtimer(CALLBACK(src, PROC_REF(clear_tricky)), TRICKERY_ANIMATION_TIME)
+	return .
+
+/datum/component/xeno_customization/proc/clear_tricky()
+	var/mob/user = parent
+	user.client?.images -= render_source_atom.trickery_image
+
+#undef TRICKERY_ANIMATION_TIME

--- a/modular/xeno_customization/code/component.dm
+++ b/modular/xeno_customization/code/component.dm
@@ -316,17 +316,27 @@
 	UnregisterSignal(parent_xeno, COMSIG_SEETHROUGH_UNTRICK)
 	. = ..()
 
+/atom/movable/xeno_customization_vis_obj/proc/copy_image_for_trickery(image/source)
+	var/image/copy = image(source, src)
+	copy.appearance = source.appearance
+	copy.vis_contents = source.vis_contents.Copy()
+	copy.filters = source.filters
+	copy.layer = source.layer
+	for(var/atom/movable/visible in copy.vis_contents)
+		visible.plane = SEETHROUGH_PLANE
+	return copy
+
 /atom/movable/xeno_customization_vis_obj/proc/trick_mob()
 	SIGNAL_HANDLER
 	. = COMPONENT_SEETHROUGH_TRICKED
 
 	switch(parent_xeno.client.prefs.xeno_customization_visibility)
 		if(XENO_CUSTOMIZATION_SHOW_ALL)
-			trickery_image = image(non_lore_image, src)
+			trickery_image = copy_image_for_trickery(non_lore_image)
 		if(XENO_CUSTOMIZATION_SHOW_LORE_FRIENDLY)
-			trickery_image = image(lore_image, src)
+			trickery_image = copy_image_for_trickery(lore_image)
 		else
-			trickery_image = image(src, src)
+			trickery_image = image(src, parent_xeno)
 	trickery_image.override = TRUE
 	trickery_image.plane = SEETHROUGH_PLANE
 	trickery_image.pixel_x = 0
@@ -334,16 +344,24 @@
 
 	parent_xeno.client.images += trickery_image
 	animate(trickery_image, alpha = 100, time = TRICKERY_ANIMATION_TIME)
+	for(var/atom/movable/visible in trickery_image.vis_contents)
+		animate(visible, alpha = 100, time = TRICKERY_ANIMATION_TIME)
+	RegisterSignal(parent_xeno, list(COMSIG_MOB_LOGOUT, COMSIG_MOB_GHOSTIZE), PROC_REF(untrick_mob))
 
 /atom/movable/xeno_customization_vis_obj/proc/untrick_mob()
 	SIGNAL_HANDLER
 	. = COMPONENT_SEETHROUGH_UNTRICKED
 
 	animate(trickery_image, alpha = 255, time = TRICKERY_ANIMATION_TIME)
+	for(var/atom/movable/visible in trickery_image.vis_contents)
+		animate(visible, alpha = 255, time = TRICKERY_ANIMATION_TIME)
 	addtimer(CALLBACK(src, PROC_REF(clear_tricky)), TRICKERY_ANIMATION_TIME)
 
 /atom/movable/xeno_customization_vis_obj/proc/clear_tricky()
+	SIGNAL_HANDLER
+
 	parent_xeno.client?.images -= trickery_image
 	QDEL_NULL(trickery_image)
+	UnregisterSignal(parent_xeno, list(COMSIG_MOB_LOGOUT, COMSIG_MOB_GHOSTIZE))
 
 #undef TRICKERY_ANIMATION_TIME

--- a/modular/xeno_customization/code/component.dm
+++ b/modular/xeno_customization/code/component.dm
@@ -5,9 +5,9 @@
 	/// The thing to show
 	var/datum/xeno_customization_option/option
 	/// What the selected option is showing, be it an overlay or full body replacement
-	var/atom/movable/to_show
+	var/atom/movable/xeno_customization_part/to_show
 	/// Is how we subtract parts of an icon, by showing it and applying subtract_filter to an image
-	var/atom/movable/to_remove
+	var/atom/movable/xeno_customization_part/subtract/to_remove
 	/// Our filter that allows to subtract parts of (or an entire) icon
 	var/dm_filter/subtract_filter
 	/// List of players who are ready/already see customization
@@ -195,6 +195,7 @@
 		to_remove.icon = subtract_icon_path
 		to_remove.vis_flags |= VIS_INHERIT_DIR | VIS_INHERIT_ID | VIS_INHERIT_LAYER | VIS_INHERIT_PLANE
 		to_remove.render_target = "*subtract_filter_[REF(src)]"
+		to_remove.appearance_flags |= RESET_ALPHA
 		subtract_filter = filter(type="alpha", render_source = to_remove.render_target, flags = MASK_INVERSE)
 	if(!to_remove)
 		return
@@ -322,8 +323,15 @@
 	copy.vis_contents = source.vis_contents.Copy()
 	copy.filters = source.filters
 	copy.layer = source.layer
-	for(var/atom/movable/visible in copy.vis_contents)
+	for(var/atom/movable/xeno_customization_part/visible in copy.vis_contents)
 		visible.plane = SEETHROUGH_PLANE
+		if(!visible.is_subtract)
+			continue
+		// visible.alpha = 999
+		// visible.appearance_flags
+		// visible.render_target = "*subtract_filter_[REF(src)]"
+		// var/subtract_filter = filter(type="alpha", render_source = visible.render_target, flags = MASK_INVERSE)
+		// copy.filters += subtract_filter
 	return copy
 
 /atom/movable/xeno_customization_vis_obj/proc/trick_mob()
@@ -336,7 +344,7 @@
 		if(XENO_CUSTOMIZATION_SHOW_LORE_FRIENDLY)
 			trickery_image = copy_image_for_trickery(lore_image)
 		else
-			trickery_image = image(src, parent_xeno)
+			trickery_image = image(src, src)
 	trickery_image.override = TRUE
 	trickery_image.plane = SEETHROUGH_PLANE
 	trickery_image.pixel_x = 0
@@ -344,7 +352,9 @@
 
 	parent_xeno.client.images += trickery_image
 	animate(trickery_image, alpha = 100, time = TRICKERY_ANIMATION_TIME)
-	for(var/atom/movable/visible in trickery_image.vis_contents)
+	for(var/atom/movable/xeno_customization_part/visible in trickery_image.vis_contents)
+		if(visible.is_subtract)
+			continue
 		animate(visible, alpha = 100, time = TRICKERY_ANIMATION_TIME)
 	RegisterSignal(parent_xeno, list(COMSIG_MOB_LOGOUT, COMSIG_MOB_GHOSTIZE), PROC_REF(untrick_mob))
 
@@ -353,7 +363,9 @@
 	. = COMPONENT_SEETHROUGH_UNTRICKED
 
 	animate(trickery_image, alpha = 255, time = TRICKERY_ANIMATION_TIME)
-	for(var/atom/movable/visible in trickery_image.vis_contents)
+	for(var/atom/movable/xeno_customization_part/visible in trickery_image.vis_contents)
+		if(visible.is_subtract)
+			continue
 		animate(visible, alpha = 255, time = TRICKERY_ANIMATION_TIME)
 	addtimer(CALLBACK(src, PROC_REF(clear_tricky)), TRICKERY_ANIMATION_TIME)
 
@@ -363,5 +375,11 @@
 	parent_xeno.client?.images -= trickery_image
 	QDEL_NULL(trickery_image)
 	UnregisterSignal(parent_xeno, list(COMSIG_MOB_LOGOUT, COMSIG_MOB_GHOSTIZE))
+
+/atom/movable/xeno_customization_part
+	var/is_subtract = FALSE
+
+/atom/movable/xeno_customization_part/subtract
+	is_subtract = TRUE
 
 #undef TRICKERY_ANIMATION_TIME

--- a/modular/xeno_customization/code/component.dm
+++ b/modular/xeno_customization/code/component.dm
@@ -22,8 +22,7 @@
 	/// Is customization currently allowed to update? Used for strain check.
 	var/updating = TRUE
 
-	/// Seethrough is using the same render_target/source logic as we do, so we must copy the same effect
-	var/seethrough_active = FALSE
+	var/image/trickery_image
 
 /datum/component/xeno_customization/Initialize(datum/xeno_customization_option/option, list/mob/override_viewers)
 	if(!isxeno(parent))
@@ -169,8 +168,6 @@
 /// Adding images to player's screen
 /datum/component/xeno_customization/proc/check_visibility_pref(mob/user)
 	remove_from_player_view(user)
-	if(user == parent && seethrough_active)
-		return
 	switch(user.client.prefs.xeno_customization_visibility)
 		if(XENO_CUSTOMIZATION_SHOW_ALL)
 			// Only Xenos and Observers can see Non-Lore-Friendly customizations
@@ -312,52 +309,67 @@
 	non_lore_image.pixel_y = 0
 	lore_image.pixel_y = 0
 
+	RegisterSignal(parent_xeno, COMSIG_SEETHROUGH_TRICK, PROC_REF(trick_mob))
+	RegisterSignal(parent_xeno, COMSIG_SEETHROUGH_UNTRICK, PROC_REF(untrick_mob))
+
 /atom/movable/xeno_customization_vis_obj/Destroy(force)
 	parent_xeno.render_target = initial_render_target_value
 	parent_xeno.vis_contents -= src
 	QDEL_NULL(non_lore_image)
 	QDEL_NULL(lore_image)
 	QDEL_NULL(trickery_image)
+	UnregisterSignal(parent_xeno, COMSIG_SEETHROUGH_TRICK)
+	UnregisterSignal(parent_xeno, COMSIG_SEETHROUGH_UNTRICK)
 	. = ..()
+
+/atom/movable/xeno_customization_vis_obj/proc/trick_mob()
+	SIGNAL_HANDLER
+	. = COMPONENT_SEETHROUGH_TRICKED
+
+	var/atom/movable/what_trickery
+	switch(parent_xeno.client.prefs.xeno_customization_visibility)
+		if(XENO_CUSTOMIZATION_SHOW_ALL)
+			what_trickery = non_lore_image
+		if(XENO_CUSTOMIZATION_SHOW_LORE_FRIENDLY)
+			what_trickery = lore_image
+		else
+			what_trickery = src
+	trickery_image = image(what_trickery, src)
+	trickery_image.override = TRUE
+	trickery_image.plane = SEETHROUGH_PLANE
+	trickery_image.pixel_x = 0
+	trickery_image.pixel_y = 0
+
+	parent_xeno.client.images += trickery_image
+	animate(trickery_image, alpha = 100, time = TRICKERY_ANIMATION_TIME)
+
+/atom/movable/xeno_customization_vis_obj/proc/untrick_mob()
+	SIGNAL_HANDLER
+	. = COMPONENT_SEETHROUGH_UNTRICKED
+
+	animate(trickery_image, alpha = 255, time = TRICKERY_ANIMATION_TIME)
+	addtimer(CALLBACK(src, PROC_REF(clear_tricky)), TRICKERY_ANIMATION_TIME)
+
+/atom/movable/xeno_customization_vis_obj/proc/clear_tricky()
+	parent_xeno.client?.images -= trickery_image
+	QDEL_NULL(trickery_image)
 
 /datum/component/xeno_customization/proc/trick_mob()
 	SIGNAL_HANDLER
 
-	. = COMPONENT_SEETHROUGH_TRICKED
-	var/mob/user = parent
-	seethrough_active = TRUE
-	var/pref = user.client.prefs.xeno_customization_visibility
-	var/atom/movable/what_trickery
-	switch(pref)
-		if(XENO_CUSTOMIZATION_SHOW_ALL)
-			what_trickery = render_source_atom.non_lore_image
-		if(XENO_CUSTOMIZATION_SHOW_LORE_FRIENDLY)
-			what_trickery = render_source_atom.lore_image
-		else
-			what_trickery = render_source_atom
-	render_source_atom.trickery_image = new(what_trickery)
-	render_source_atom.trickery_image.loc = render_source_atom
-	render_source_atom.trickery_image.override = TRUE
-	render_source_atom.trickery_image.plane = SEETHROUGH_PLANE
-
-	user.client.images += render_source_atom.trickery_image
-
-	animate(render_source_atom.trickery_image, alpha = 100, time = TRICKERY_ANIMATION_TIME)
-	return .
+	// remove_from_player_view(parent)
+	// animate(trickery_image, alpha = 100, time = TRICKERY_ANIMATION_TIME)
 
 /datum/component/xeno_customization/proc/untrick_mob()
 	SIGNAL_HANDLER
 
-	. = COMPONENT_SEETHROUGH_UNTRICKED
-	seethrough_active = FALSE
-	if(!render_source_atom.trickery_image)
-		return .
-	animate(render_source_atom.trickery_image, alpha = 255, time = TRICKERY_ANIMATION_TIME)
-	addtimer(CALLBACK(src, PROC_REF(clear_tricky)), TRICKERY_ANIMATION_TIME)
-	return .
+	// animate(trickery_image, alpha = 255, time = TRICKERY_ANIMATION_TIME)
+	// addtimer(CALLBACK(src, PROC_REF(clear_tricky)), TRICKERY_ANIMATION_TIME)
 
 /datum/component/xeno_customization/proc/clear_tricky()
-	var/mob/user = parent
-	user.client?.images -= render_source_atom.trickery_image
+	// var/mob/user = parent
+	// user.client?.images -= trickery_image
+	// QDEL_NULL(trickery_image)
+	// add_to_player_view(parent)
 
 #undef TRICKERY_ANIMATION_TIME

--- a/modular/xeno_customization/code/customization_datum.dm
+++ b/modular/xeno_customization/code/customization_datum.dm
@@ -72,7 +72,6 @@ GLOBAL_LIST_INIT(xeno_customizations_by_caste, setup_all_xeno_customizations())
 		if(get_job_playtime(user, caste) < timelock)
 			var/hours = timelock / (1 HOURS)
 			. += "Необходимое время на этой касте: [hours] час[declension_ru(hours, "", "а", "ов")]. "
-	. = "Кастомизация ксеноморфов временно отключена!"
 	return .
 
 /datum/xeno_customization_option/proc/is_correctly_configured()


### PR DESCRIPTION

## Что этот PR делает
Теперь кастомизации заработали с "полувидимостью себя". Восславим же кастомизацию!

fixes https://github.com/ss220club/BandaMarines/issues/642

## Changelog
:cl:
fix: Кастомизация ксеноморфов теперь корректно работает с Seethrough Mob действием.
/:cl:
