### PR TITLE
Translation fixes for shiva&522 LZs and cargo crate

### DIFF
--- a/modular/translations/code/translation_data/ru_names/cm13_areas.toml
+++ b/modular/translations/code/translation_data/ru_names/cm13_areas.toml
@@ -118,7 +118,7 @@ prepositional = "зоне посадки 2 на «Землю Шанса»"
 gender = "female"
 tags = [ "cm13",]
 
-["Chance's Claim - Dropship Alamo Landing Zone"]
+["chance's claim - dropship alamo landing zone"]
 nominative = "зона посадки 1 «Служебный терминал»"
 genitive = "зоны посадки 1 «Служебный терминал»"
 dative = "зоне посадки 1 «Служебный терминал»"
@@ -128,7 +128,7 @@ prepositional = "зоне посадки 1 «Служебный терминал
 gender = "female"
 tags = [ "cm13",]
 
-["Chance's Claim - Dropship Normandy Landing Zone"]
+["chance's claim - dropship normandy landing zone"]
 nominative = "зона посадки 2 «Грузовой терминал»"
 genitive = "зоны посадки 2 «Грузовой терминал»"
 dative = "зоне посадки 2 «Грузовой терминал»"
@@ -178,7 +178,7 @@ prepositional = "зоне посадки 2 на «Снежный шар Шивы
 gender = "female"
 tags = [ "cm13",]
 
-["Shiva's Snowball - Landing Valley"]
+["shiva's snowball - landing valley"]
 nominative = "зона посадки 1 «Дополнительная ВПП»"
 genitive = "зоны посадки 1 «Дополнительная ВПП»"
 dative = "зоне посадки 1 «Дополнительная ВПП»"
@@ -188,7 +188,7 @@ prepositional = "зоне посадки 1 «Дополнительная ВПП
 gender = "female"
 tags = [ "cm13",]
 
-["Shiva's Snowball - Dropship Normandy Console"]
+["shiva's snowball - dropship normandy console"]
 nominative = "зона посадки 2 «Аэродром»"
 genitive = "зоны посадки 2 «Аэродром»"
 dative = "зоне посадки 2 «Аэродром»"

--- a/modular/translations/code/translation_data/ru_names/cm13_areas.toml
+++ b/modular/translations/code/translation_data/ru_names/cm13_areas.toml
@@ -118,26 +118,6 @@ prepositional = "зоне посадки 2 на «Землю Шанса»"
 gender = "female"
 tags = [ "cm13",]
 
-["Chance's Claim - Dropship Alamo Landing Zone"]
-nominative = "зона посадки 1 «Служебный терминал»"
-genitive = "зоны посадки 1 «Служебный терминал»"
-dative = "зоне посадки 1 «Служебный терминал»"
-accusative = "зону посадки 1 «Служебный терминал»"
-instrumental = "зоной посадки 1 «Служебный терминал»"
-prepositional = "зоне посадки 1 «Служебный терминал»"
-gender = "female"
-tags = [ "cm13",]
-
-["Chance's Claim - Dropship Normandy Landing Zone"]
-nominative = "зона посадки 2 «Грузовой терминал»"
-genitive = "зоны посадки 2 «Грузовой терминал»"
-dative = "зоне посадки 2 «Грузовой терминал»"
-accusative = "зону посадки 2 «Грузовой терминал»"
-instrumental = "зоной посадки 2 «Грузовой терминал»"
-prepositional = "зоне посадки 2 «Грузовой терминал»"
-gender = "female"
-tags = [ "cm13",]
-
 ["nova medica hospital complex - emergency response - landing zone one"]
 nominative = "зона посадки 1 «Экстренное реагирование больничного комплекса Нова Медика»"
 genitive = "зоны посадки 1 «Экстренное реагирование больничного комплекса Нова Медика»"
@@ -169,22 +149,12 @@ gender = "female"
 tags = [ "cm13",]
 
 ["shiva's snowball - dropship normandy landing zone"]
-nominative = "зона посадки 2 «Аэродром»"
-genitive = "зоны посадки 2 «Аэродром»"
-dative = "зоне посадки 2 «Аэродром»"
-accusative = "зону посадки 2 «Аэродром»"
-instrumental = "зоной посадки 2 «Аэродром»"
-prepositional = "зоне посадки 2 «Аэродром»"
-gender = "female"
-tags = [ "cm13",]
-
-["Shiva's Snowball - Landing Valley"]
-nominative = "зона посадки 1 «Дополнительная ВПП»"
-genitive = "зоны посадки 1 «Дополнительная ВПП»"
-dative = "зоне посадки 1 «Дополнительная ВПП»"
-accusative = "зону посадки 1 «Дополнительная ВПП»"
-instrumental = "зоной посадки 1 «Дополнительная ВПП»"
-prepositional = "зоне посадки 1 «Дополнительная ВПП»"
+nominative = "зона посадки 2 на «Снежный шар Шивы» для Нормандии"
+genitive = "зоны посадки 2 на «Снежный шар Шивы» для Нормандии"
+dative = "зоне посадки 2 на «Снежный шар Шивы» для Нормандии"
+accusative = "зону посадки 2 на «Снежный шар Шивы» для Нормандии"
+instrumental = "зоной посадки 2 на «Снежный шар Шивы» для Нормандии"
+prepositional = "зоне посадки 2 на «Снежный шар Шивы» для Нормандии"
 gender = "female"
 tags = [ "cm13",]
 

--- a/modular/translations/code/translation_data/ru_names/cm13_areas.toml
+++ b/modular/translations/code/translation_data/ru_names/cm13_areas.toml
@@ -118,6 +118,26 @@ prepositional = "зоне посадки 2 на «Землю Шанса»"
 gender = "female"
 tags = [ "cm13",]
 
+["Chance's Claim - Dropship Alamo Landing Zone"]
+nominative = "зона посадки 1 «Служебный терминал»"
+genitive = "зоны посадки 1 «Служебный терминал»"
+dative = "зоне посадки 1 «Служебный терминал»"
+accusative = "зону посадки 1 «Служебный терминал»"
+instrumental = "зоной посадки 1 «Служебный терминал»"
+prepositional = "зоне посадки 1 «Служебный терминал»"
+gender = "female"
+tags = [ "cm13",]
+
+["Chance's Claim - Dropship Normandy Landing Zone"]
+nominative = "зона посадки 2 «Грузовой терминал»"
+genitive = "зоны посадки 2 «Грузовой терминал»"
+dative = "зоне посадки 2 «Грузовой терминал»"
+accusative = "зону посадки 2 «Грузовой терминал»"
+instrumental = "зоной посадки 2 «Грузовой терминал»"
+prepositional = "зоне посадки 2 «Грузовой терминал»"
+gender = "female"
+tags = [ "cm13",]
+
 ["nova medica hospital complex - emergency response - landing zone one"]
 nominative = "зона посадки 1 «Экстренное реагирование больничного комплекса Нова Медика»"
 genitive = "зоны посадки 1 «Экстренное реагирование больничного комплекса Нова Медика»"
@@ -149,12 +169,22 @@ gender = "female"
 tags = [ "cm13",]
 
 ["shiva's snowball - dropship normandy landing zone"]
-nominative = "зона посадки 2 на «Снежный шар Шивы» для Нормандии"
-genitive = "зоны посадки 2 на «Снежный шар Шивы» для Нормандии"
-dative = "зоне посадки 2 на «Снежный шар Шивы» для Нормандии"
-accusative = "зону посадки 2 на «Снежный шар Шивы» для Нормандии"
-instrumental = "зоной посадки 2 на «Снежный шар Шивы» для Нормандии"
-prepositional = "зоне посадки 2 на «Снежный шар Шивы» для Нормандии"
+nominative = "зона посадки 2 «Аэродром»"
+genitive = "зоны посадки 2 «Аэродром»"
+dative = "зоне посадки 2 «Аэродром»"
+accusative = "зону посадки 2 «Аэродром»"
+instrumental = "зоной посадки 2 «Аэродром»"
+prepositional = "зоне посадки 2 «Аэродром»"
+gender = "female"
+tags = [ "cm13",]
+
+["Shiva's Snowball - Landing Valley"]
+nominative = "зона посадки 1 «Дополнительная ВПП»"
+genitive = "зоны посадки 1 «Дополнительная ВПП»"
+dative = "зоне посадки 1 «Дополнительная ВПП»"
+accusative = "зону посадки 1 «Дополнительная ВПП»"
+instrumental = "зоной посадки 1 «Дополнительная ВПП»"
+prepositional = "зоне посадки 1 «Дополнительная ВПП»"
 gender = "female"
 tags = [ "cm13",]
 

--- a/modular/translations/code/translation_data/ru_names/cm13_areas.toml
+++ b/modular/translations/code/translation_data/ru_names/cm13_areas.toml
@@ -118,6 +118,26 @@ prepositional = "зоне посадки 2 на «Землю Шанса»"
 gender = "female"
 tags = [ "cm13",]
 
+["Chance's Claim - Dropship Alamo Landing Zone"]
+nominative = "зона посадки 1 «Служебный терминал»"
+genitive = "зоны посадки 1 «Служебный терминал»"
+dative = "зоне посадки 1 «Служебный терминал»"
+accusative = "зону посадки 1 «Служебный терминал»"
+instrumental = "зоной посадки 1 «Служебный терминал»"
+prepositional = "зоне посадки 1 «Служебный терминал»"
+gender = "female"
+tags = [ "cm13",]
+
+["Chance's Claim - Dropship Normandy Landing Zone"]
+nominative = "зона посадки 2 «Грузовой терминал»"
+genitive = "зоны посадки 2 «Грузовой терминал»"
+dative = "зоне посадки 2 «Грузовой терминал»"
+accusative = "зону посадки 2 «Грузовой терминал»"
+instrumental = "зоной посадки 2 «Грузовой терминал»"
+prepositional = "зоне посадки 2 «Грузовой терминал»"
+gender = "female"
+tags = [ "cm13",]
+
 ["nova medica hospital complex - emergency response - landing zone one"]
 nominative = "зона посадки 1 «Экстренное реагирование больничного комплекса Нова Медика»"
 genitive = "зоны посадки 1 «Экстренное реагирование больничного комплекса Нова Медика»"
@@ -155,6 +175,26 @@ dative = "зоне посадки 2 на «Снежный шар Шивы» дл
 accusative = "зону посадки 2 на «Снежный шар Шивы» для Нормандии"
 instrumental = "зоной посадки 2 на «Снежный шар Шивы» для Нормандии"
 prepositional = "зоне посадки 2 на «Снежный шар Шивы» для Нормандии"
+gender = "female"
+tags = [ "cm13",]
+
+["Shiva's Snowball - Landing Valley"]
+nominative = "зона посадки 1 «Дополнительная ВПП»"
+genitive = "зоны посадки 1 «Дополнительная ВПП»"
+dative = "зоне посадки 1 «Дополнительная ВПП»"
+accusative = "зону посадки 1 «Дополнительная ВПП»"
+instrumental = "зоной посадки 1 «Дополнительная ВПП»"
+prepositional = "зоне посадки 1 «Дополнительная ВПП»"
+gender = "female"
+tags = [ "cm13",]
+
+["Shiva's Snowball - Dropship Normandy Console"]
+nominative = "зона посадки 2 «Аэродром»"
+genitive = "зоны посадки 2 «Аэродром»"
+dative = "зоне посадки 2 «Аэродром»"
+accusative = "зону посадки 2 «Аэродром»"
+instrumental = "зоной посадки 2 «Аэродром»"
+prepositional = "зоне посадки 2 «Аэродром»"
 gender = "female"
 tags = [ "cm13",]
 

--- a/modular/translations/code/translation_data/ru_names/cm13_equipment.toml
+++ b/modular/translations/code/translation_data/ru_names/cm13_equipment.toml
@@ -788,7 +788,7 @@ nominative = "ящик для снабжения (противогаз x 3, во
 tags = [ "nominative_only", "cm13",]
 
 ["emergency equipment (x2 toolbox, x2 hazard vest, x5 oxygen tank, x5 masks)"]
-nominative = "ящик для снабжения (ящик для инструментов x 2, сигнальный жилет x 2, кислородный баллон x 5, противогаз x 5)"
+nominative = "ящик для снабжения (язик для инструментов x 2, сигнальный жилет x 2, кислородный баллон x 5, противогаз x 5)"
 tags = [ "nominative_only", "cm13",]
 
 ["empty boxes (x10)"]

--- a/modular/translations/code/translation_data/ru_names/cm13_equipment.toml
+++ b/modular/translations/code/translation_data/ru_names/cm13_equipment.toml
@@ -788,7 +788,7 @@ nominative = "ящик для снабжения (противогаз x 3, во
 tags = [ "nominative_only", "cm13",]
 
 ["emergency equipment (x2 toolbox, x2 hazard vest, x5 oxygen tank, x5 masks)"]
-nominative = "ящик для снабжения (язик для инструментов x 2, сигнальный жилет x 2, кислородный баллон x 5, противогаз x 5)"
+nominative = "ящик для снабжения (ящик для инструментов x 2, сигнальный жилет x 2, кислородный баллон x 5, противогаз x 5)"
 tags = [ "nominative_only", "cm13",]
 
 ["empty boxes (x10)"]


### PR DESCRIPTION
## Что этот PR делает

Добавляет понятный перевод для посадочных зон в консоли КИКа для карт Shiva и 522. Теперь по названию и карте можно как-то понять, где какое ЛЗ. + фикс очепятки для ящика снабжения

## Почему это хорошо для игры

очевидно

## Изображения изменений

не покажу

## Тестирование

локалка

## Changelog

:cl: JHINgle4ce
typo: Перевод ЛЗ на Шиве и 522 в консоли кика, чтобы по карте можно было сопоставить с названием
typo: Фикс очепятки в имени ящика снабжения
/:cl: