### PR TITLE
Remove quickcast from non-xeno

### DIFF
--- a/modular/quick_cast/code/quick_cast.dm
+++ b/modular/quick_cast/code/quick_cast.dm
@@ -29,7 +29,3 @@
 }
 
 QUICK_CAST_OVERRIDE(/xeno_action/activable)
-QUICK_CAST_OVERRIDE(/human_action/activable)
-QUICK_CAST_OVERRIDE(/item_action/hover)
-QUICK_CAST_OVERRIDE(/item_action/specialist/aimed_shot)
-QUICK_CAST_OVERRIDE(/item_action/specialist/spotter_target)


### PR DESCRIPTION

## Что этот PR делает
Убирает квиккаст у всего, что не есть ксено. Они так и так не работали, так еще и ломали.

fixes https://github.com/ss220club/BandaMarines/issues/661

## Changelog
:cl:
fix: Исправление "залипания" ПКМ (или другой кнопки активации способности) у снайпера и наводчика.
/:cl:
