### PR TITLE
Admin_ranks logic

### DIFF
--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -152,12 +152,19 @@ GLOBAL_LIST_EMPTY(admin_ranks) //list of all ranks with associated rights
 
 	//rank follows the first "-"
 	var/rank = ""
+	var/rights = NONE //SS220 EDIT START
+	var/list/extra_titles = list()
 	if(length(List) >= 2)
 		rank = ckeyEx(List[2])
+		rights |= GLOB.admin_ranks[rank]
 
-	var/list/extra_titles = list()
-	if(length(List) >= 3)
-		extra_titles = List.Copy(3)
+	for(var/i = 3, i <= length(List), i++)
+		var/value = ckeyEx(List[i])
+
+		if(value in GLOB.admin_ranks)
+			rights |= GLOB.admin_ranks[value]
+
+		extra_titles += List[i] //SS220 EDIT END
 
 	if(mentor)
 		if(!(LAZYISIN(MentorRanks, rank)))
@@ -166,7 +173,7 @@ GLOBAL_LIST_EMPTY(admin_ranks) //list of all ranks with associated rights
 			return
 
 	//load permissions associated with this rank
-	var/rights = GLOB.admin_ranks[rank]
+	//var/rights = GLOB.admin_ranks[rank] //SS220 EDIT
 
 	//create the admin datum and store it for later use
 	var/datum/admins/D = new /datum/admins(rank, rights, ckey, extra_titles)


### PR DESCRIPTION
## Что этот PR делает

Изменяет логику обработки плашек (рангов) таким образом, что их права теперь суммируются.

Теперь при наличии нескольких плашек пользователь получает объединённый набор прав из каждой из них независимо от порядка в списке. При этом первая плашка по-прежнему используется для заполнения переменной `Rank`.

## Почему это хорошо для игры

Позволяет гибко комбинировать роли без необходимости создавать отдельные плашки под каждое сочетание прав. Также устраняет зависимость набора прав от порядка перечисления плашек, делая систему более предсказуемой и удобной в использовании.

## Тестирование
<img width="511" height="39" alt="Скриншот 16-07-2026 163724" src="https://github.com/user-attachments/assets/5f0b41d0-c795-4fea-b63b-44efd701bb15" />
<img width="830" height="438" alt="Скриншот 16-07-2026 165134" src="https://github.com/user-attachments/assets/633a0576-4c44-4849-b277-f0dab0614e9c" />

* Проверено, что права из нескольких плашек корректно объединяются.
* Проверено, что порядок перечисления плашек не влияет на итоговый набор прав.
* Проверено, что первая плашка в списке по-прежнему записывается в переменную `Rank`.

## Changelog

:cl:
qol: Права нескольких плашек теперь объединяются независимо от их порядка, при этом первая плашка по-прежнему используется как основной ранг.
/:cl:
