### PR TITLE
[TM ONLY] Crusher charge improvements

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -120,6 +120,7 @@
 #define NO_PERMANENT_DAMAGE (1<<20)
 #define CORRUPTED_ALLY (1<<21)
 #define FAKESOUL (1<<22) // Lets things without souls pretend like they do
+#define CRUSHER_CHARGING (1<<23) // Crusher is charging through mobs
 
 // =============================
 // hive types

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -122,7 +122,6 @@
 #define CORRUPTED_ALLY (1<<21)
 #define FAKESOUL (1<<22) // Lets things without souls pretend like they do
 // NOTE: Don't add flags past 1<<23, it'll break things due to BYOND limitations. You can usually use a Component instead.
-#define CRUSHER_CHARGING (1<<23) // Crusher is charging through mobs
 
 // =============================
 // hive types
@@ -153,6 +152,7 @@
 // slowdowns
 #define XENO_SLOWED_AMOUNT 0.7
 #define XENO_SUPERSLOWED_AMOUNT 1.5
+#define XENO_CRUSHER_CHARGE_SLOWDOWN 3
 #define HUMAN_SLOWED_AMOUNT 2
 #define HUMAN_SUPERSLOWED_AMOUNT 4
 

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -122,6 +122,7 @@
 #define CORRUPTED_ALLY (1<<21)
 #define FAKESOUL (1<<22) // Lets things without souls pretend like they do
 // NOTE: Don't add flags past 1<<23, it'll break things due to BYOND limitations. You can usually use a Component instead.
+#define CRUSHER_CHARGING (1<<23) // Crusher is charging through mobs
 
 // =============================
 // hive types

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -219,6 +219,8 @@
 #define TRAIT_DEXTROUS "t_dextrous"
 /// If the mob is currently charging (xeno only)
 #define TRAIT_CHARGING "t_charging"
+/// If the mob is currently performing a crusher charge (xeno only)
+#define TRAIT_CRUSHER_CHARGING "t_crusher_charging"
 /// If the mob has leadership abilities (giving orders).
 #define TRAIT_LEADERSHIP "t_leadership"
 /// If the mob is a acting squad leader (incapable of the leadership abilities).
@@ -387,6 +389,7 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 		"TRAIT_NEARSIGHTED_EQUIPMENT" = TRAIT_NEARSIGHTED_EQUIPMENT,
 		"TRAIT_DEXTROUS" = TRAIT_DEXTROUS,
 		"TRAIT_CHARGING" = TRAIT_CHARGING,
+		"TRAIT_CRUSHER_CHARGING" = TRAIT_CRUSHER_CHARGING,
 		"TRAIT_LEADERSHIP" = TRAIT_LEADERSHIP,
 		"TRAIT_REAGENT_SCANNER" = TRAIT_REAGENT_SCANNER,
 		"TRAIT_SPOTTER_LAZED" = TRAIT_SPOTTER_LAZED,

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -545,17 +545,37 @@
 
 
 //Welp
+/mob/living/carbon/xenomorph/var/xeno_jitter_timer_id = TIMER_ID_NULL
+
 /mob/living/carbon/xenomorph/proc/xeno_jitter(jitter_time = 25)
+	set waitfor = 0
+
+	// Cancel any jitter already in progress so chains don't overlap.
+	stop_xeno_jitter()
+
+	_xeno_jitter_tick(jitter_time)
+
+/mob/living/carbon/xenomorph/proc/_xeno_jitter_tick(jitter_time)
 	set waitfor = 0
 
 	pixel_x = old_x + rand(-3, 3)
 	pixel_y = old_y + rand(-1, 1)
 	jitter_time--
 
-	if(jitter_time)
-		addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living/carbon/xenomorph, xeno_jitter), jitter_time), 1) // The fuck, use a processing SS, TODO FIXME AHH
+	if(jitter_time > 0)
+		xeno_jitter_timer_id = addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living/carbon/xenomorph, _xeno_jitter_tick), jitter_time), 1, TIMER_STOPPABLE)
 	else
+		xeno_jitter_timer_id = TIMER_ID_NULL
 		//endwhile - reset the pixel offsets to zero
+		pixel_x = old_x
+		pixel_y = old_y
+
+/// Cancels any active xeno_jitter chain and resets pixel offsets to their base values.
+/// Safe to call when no jitter is active (no-op in that case).
+/mob/living/carbon/xenomorph/proc/stop_xeno_jitter()
+	if(xeno_jitter_timer_id != TIMER_ID_NULL)
+		deltimer(xeno_jitter_timer_id)
+		xeno_jitter_timer_id = TIMER_ID_NULL
 		pixel_x = old_x
 		pixel_y = old_y
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
@@ -32,11 +32,8 @@
 /datum/action/xeno_action/activable/pounce/crusher_charge/New()
 	. = ..()
 	not_reducing_objects = typesof(/obj/structure/barricade) + typesof(/obj/structure/machinery/defenses)
-	// Override collision callbacks to pass through mobs
+	// We'll use signals instead of collision_callbacks for better control
 	pounce_callbacks = list()
-	pounce_callbacks[/mob/living/carbon/human] = CALLBACK(src, PROC_REF(handle_human_collision))
-	pounce_callbacks[/mob/living/carbon/xenomorph] = CALLBACK(src, PROC_REF(handle_xeno_collision))
-	pounce_callbacks[/mob/living/carbon] = CALLBACK(src, PROC_REF(handle_mob_collision))
 	pounce_callbacks[/obj] = DYNAMIC(/mob/living/carbon/xenomorph/proc/pounced_obj_wrapper)
 	pounce_callbacks[/turf] = DYNAMIC(/mob/living/carbon/xenomorph/proc/pounced_turf_wrapper)
 
@@ -64,18 +61,24 @@
 		ADD_TRAIT(xeno, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Crusher Charge"))
 		xeno.anchored = TRUE
 
-		// Camera shake during charging
-		shake_camera(xeno, windup_duration * 0.1, windup_duration * 0.1)
+		// Apply visual effects (lowered crest)
+		pre_windup_effects()
+
+		// Make crusher jitter during charging
+		var/jitter_duration = round(windup_duration / 0.1) // Convert to ticks (1 tick = 0.1 seconds)
+		xeno.xeno_jitter(jitter_duration)
 
 		// Perform the windup with visual indicator
 		if(!do_after(xeno, windup_duration, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE))
 			to_chat(xeno, SPAN_XENODANGER("Мы отменяем зарядку рывка!"))
 			REMOVE_TRAIT(xeno, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Crusher Charge"))
 			xeno.anchored = FALSE
+			post_windup_effects(interrupted = TRUE)
 			return
 
 		REMOVE_TRAIT(xeno, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Crusher Charge"))
 		xeno.anchored = FALSE
+		// Don't call post_windup_effects here - crest stays lowered until after the charge
 
 		activated_once = TRUE
 		stored_target = target
@@ -172,15 +175,92 @@
 
 	pre_pounce_effects()
 
+	// Set flag that we're in crusher charge mode
+	xeno.status_flags |= CRUSHER_CHARGING
+
 	xeno.pounce_distance = get_dist(xeno, target)
 	if(xeno.z != target.z)
 		xeno.pounce_distance += 2
-	xeno.throw_atom(target, distance, throw_speed, xeno, launch_type = LOW_LAUNCH, pass_flags = pounce_pass_flags, collision_callbacks = pounce_callbacks, tracking=TRUE)
+
+	// Allow charge to pass through mobs without stopping, but still process collisions with them
+	RegisterSignal(xeno, COMSIG_MOVABLE_TURF_ENTER, PROC_REF(charge_turf_enter))
+	RegisterSignal(xeno, COMSIG_MOVABLE_MOVED, PROC_REF(charge_moved))
+
+	xeno.throw_atom(target, distance, throw_speed, xeno, launch_type = LOW_LAUNCH, pass_flags = pounce_pass_flags, collision_callbacks = pounce_callbacks, end_throw_callbacks = list(CALLBACK(src, PROC_REF(charge_end))), tracking=TRUE)
 	xeno.update_icons()
+
+	return TRUE
+
+/datum/action/xeno_action/activable/pounce/crusher_charge/proc/charge_end(atom/movable/thrown_atom)
+	var/mob/living/carbon/xenomorph/xeno = owner
+	if(!istype(xeno))
+		return
+
+	UnregisterSignal(xeno, list(COMSIG_MOVABLE_TURF_ENTER, COMSIG_MOVABLE_MOVED))
+
+	// Clear flag after charge actually ends
+	xeno.status_flags &= ~CRUSHER_CHARGING
 
 	additional_effects_always()
 
-	return TRUE
+	// Raise the crest after charge is complete
+	post_windup_effects(interrupted = FALSE)
+
+	xeno.update_icons()
+
+/datum/action/xeno_action/activable/pounce/crusher_charge/proc/charge_turf_enter(mob/living/carbon/xenomorph/xeno, turf/entering_turf)
+	SIGNAL_HANDLER
+	if(!istype(xeno) || !istype(entering_turf))
+		return NONE
+
+	// Don't override if the turf itself is impassable
+	if(entering_turf.density && entering_turf.turf_flags & TURF_HULL)
+		return NONE
+
+	var/move_dir = get_dir(xeno, entering_turf)
+
+	// Only allow movement if the only blockers are living mobs
+	for(var/atom/A in entering_turf)
+		if(A == xeno || !A.can_block_movement)
+			continue
+		if(isliving(A))
+			continue
+		if(A.BlockedPassDirs(xeno, move_dir))
+			return NONE
+
+	return COMPONENT_TURF_ALLOW_MOVEMENT
+
+/datum/action/xeno_action/activable/pounce/crusher_charge/proc/charge_moved(mob/living/carbon/xenomorph/xeno, atom/oldloc, direction, forced)
+	SIGNAL_HANDLER
+	if(!istype(xeno) || !(xeno.status_flags & CRUSHER_CHARGING))
+		return
+
+	// Apply charge collision effects to every mob we moved onto
+	for(var/mob/living/M in xeno.loc)
+		if(M == xeno)
+			continue
+		if(ishuman(M))
+			INVOKE_ASYNC(src, PROC_REF(handle_human_collision), M)
+		else if(isxeno(M))
+			INVOKE_ASYNC(src, PROC_REF(handle_xeno_collision), M)
+		else
+			INVOKE_ASYNC(src, PROC_REF(handle_mob_collision), M)
+
+/datum/action/xeno_action/activable/pounce/crusher_charge/proc/handle_charge_collision(mob/living/carbon/xenomorph/xeno, atom/target_atom)
+	// Only handle mob collisions, let objects/turfs stop the charge
+	if(!isliving(target_atom))
+		return
+
+	// Call appropriate handler based on mob type
+	if(ishuman(target_atom))
+		handle_human_collision(target_atom)
+	else if(isxeno(target_atom))
+		handle_xeno_collision(target_atom)
+	else if(isliving(target_atom))
+		handle_mob_collision(target_atom)
+
+	// Return signal to continue movement through the mob
+	return COMPONENT_LIVING_COLLIDE_HANDLED
 
 /datum/action/xeno_action/activable/pounce/crusher_charge/proc/handle_human_collision(mob/living/carbon/human/human)
 	var/mob/living/carbon/xenomorph/xeno = owner
@@ -221,10 +301,7 @@
 		log_attack("[xeno] ([xeno.ckey]) crusher charged [target_xeno] ([target_xeno.ckey])")
 		target_xeno.apply_damage(direct_hit_damage * 0.5, BRUTE)
 
-	if(target_xeno.anchored)
-		return
-
-	if(isqueen(target_xeno) || IS_XENO_LEADER(target_xeno) || isboiler(target_xeno))
+	if(target_xeno.anchored || isqueen(target_xeno) || IS_XENO_LEADER(target_xeno) || isboiler(target_xeno))
 		return
 
 	var/list/ram_dirs = get_perpen_dir(xeno.dir)
@@ -274,6 +351,25 @@
 
 /datum/action/xeno_action/activable/pounce/crusher_charge/initialize_pounce_pass_flags()
 	pounce_pass_flags = PASS_CRUSHER_CHARGE
+
+// Override launch_impact for xenomorphs to handle crusher charge
+/mob/living/carbon/xenomorph/launch_impact(atom/hit_atom)
+	// If crusher is charging through mobs, handle collisions differently
+	if(status_flags & CRUSHER_CHARGING && isliving(hit_atom))
+		var/datum/action/xeno_action/activable/pounce/crusher_charge/charge_ability = get_action(src, /datum/action/xeno_action/activable/pounce/crusher_charge)
+		if(charge_ability)
+			// Handle the collision but don't stop throwing
+			if(ishuman(hit_atom))
+				charge_ability.handle_human_collision(hit_atom)
+			else if(isxeno(hit_atom))
+				charge_ability.handle_xeno_collision(hit_atom)
+			else if(isliving(hit_atom))
+				charge_ability.handle_mob_collision(hit_atom)
+			// Don't set throwing = FALSE, just return to continue the charge
+			return
+
+	// Default behavior for non-crusher-charge impacts
+	return ..()
 
 /datum/action/xeno_action/onclick/crusher_stomp
 	name = "Stomp"

--- a/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
@@ -23,11 +23,254 @@
 	var/frontal_armor = 15
 	// Object types that don't reduce cooldown when hit
 	var/list/not_reducing_objects = list()
+	// Two-stage activation
+	var/activated_once = FALSE
+	var/atom/stored_target = null
+	var/charge_timeout_timer_id = TIMER_ID_NULL
 
 
 /datum/action/xeno_action/activable/pounce/crusher_charge/New()
 	. = ..()
 	not_reducing_objects = typesof(/obj/structure/barricade) + typesof(/obj/structure/machinery/defenses)
+	// Override collision callbacks to pass through mobs
+	pounce_callbacks = list()
+	pounce_callbacks[/mob/living/carbon/human] = CALLBACK(src, PROC_REF(handle_human_collision))
+	pounce_callbacks[/mob/living/carbon/xenomorph] = CALLBACK(src, PROC_REF(handle_xeno_collision))
+	pounce_callbacks[/mob/living/carbon] = CALLBACK(src, PROC_REF(handle_mob_collision))
+	pounce_callbacks[/obj] = DYNAMIC(/mob/living/carbon/xenomorph/proc/pounced_obj_wrapper)
+	pounce_callbacks[/turf] = DYNAMIC(/mob/living/carbon/xenomorph/proc/pounced_turf_wrapper)
+
+/datum/action/xeno_action/activable/pounce/crusher_charge/use_ability(atom/target)
+	var/mob/living/carbon/xenomorph/xeno = owner
+
+	if(!istype(xeno) || !xeno.check_state())
+		return
+
+	if(!activated_once && !action_cooldown_check())
+		return
+
+	if(!target || target.layer >= FLY_LAYER || !isturf(xeno.loc))
+		return
+
+	if(!activated_once)
+		// First click - start charging with windup
+		if(!check_and_use_plasma_owner())
+			return
+
+		xeno.visible_message(SPAN_XENODANGER("[capitalize(xeno.declent_ru(NOMINATIVE))] начинает заряжать рывок!"), SPAN_XENODANGER("Мы начинаем заряжать рывок!"))
+
+		// Lock direction and immobilize during charge
+		xeno.set_face_dir(get_cardinal_dir(xeno, target))
+		ADD_TRAIT(xeno, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Crusher Charge"))
+		xeno.anchored = TRUE
+
+		// Camera shake during charging
+		shake_camera(xeno, windup_duration * 0.1, windup_duration * 0.1)
+
+		// Perform the windup with visual indicator
+		if(!do_after(xeno, windup_duration, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE))
+			to_chat(xeno, SPAN_XENODANGER("Мы отменяем зарядку рывка!"))
+			REMOVE_TRAIT(xeno, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Crusher Charge"))
+			xeno.anchored = FALSE
+			return
+
+		REMOVE_TRAIT(xeno, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Crusher Charge"))
+		xeno.anchored = FALSE
+
+		activated_once = TRUE
+		stored_target = target
+		apply_cooldown()
+
+		to_chat(xeno, SPAN_XENOWARNING("Рывок заряжен! Выберите направление в течение 5 секунд!"))
+
+		// Set timeout - if no second click in 5 seconds, charge at the first target
+		charge_timeout_timer_id = addtimer(CALLBACK(src, PROC_REF(charge_timeout)), 5 SECONDS, TIMER_STOPPABLE)
+		return ..()
+	else
+		// Second click - execute charge at new target immediately (no windup)
+		activated_once = FALSE
+		if(charge_timeout_timer_id != TIMER_ID_NULL)
+			deltimer(charge_timeout_timer_id)
+			charge_timeout_timer_id = TIMER_ID_NULL
+
+		// Call execute_charge to perform the actual charge
+		return execute_charge(target)
+
+/datum/action/xeno_action/activable/pounce/crusher_charge/proc/charge_timeout()
+	var/mob/living/carbon/xenomorph/xeno = owner
+	if(!istype(xeno) || !activated_once)
+		return
+
+	activated_once = FALSE
+	charge_timeout_timer_id = TIMER_ID_NULL
+
+	if(!stored_target)
+		to_chat(xeno, SPAN_XENOWARNING("Наш рывок потерял цель!"))
+		return
+
+	to_chat(xeno, SPAN_XENOWARNING("Время вышло, мы совершаем рывок в изначальную цель!"))
+	execute_charge(stored_target)
+
+/datum/action/xeno_action/activable/pounce/crusher_charge/proc/execute_charge(atom/target)
+	var/mob/living/carbon/xenomorph/xeno = owner
+
+	if(!target)
+		return FALSE
+
+	while(istype(target, /turf/open_space))
+		target = SSmapping.get_turf_below(target)
+
+	if(target.layer >= FLY_LAYER)
+		return FALSE
+
+	if(!isturf(xeno.loc))
+		to_chat(xeno, SPAN_XENOWARNING("Мы не можем осуществить [action_text] отсюда!"))
+		return FALSE
+
+	if(!xeno.check_state())
+		return FALSE
+
+	if(xeno.legcuffed)
+		to_chat(xeno, SPAN_XENODANGER("Мы не можем [action_text] с этой штукой на ноге!"))
+		return FALSE
+
+	if(xeno.layer == XENO_HIDING_LAYER)
+		var/datum/action/xeno_action/onclick/xenohide/hide = get_action(xeno, /datum/action/xeno_action/onclick/xenohide)
+		if(hide)
+			hide.post_attack()
+
+	if(!tracks_target)
+		target = get_turf(target)
+
+	if(target.z != xeno.z)
+		var/maximum_z = max(target.z, xeno.z)
+		var/list/turf/path = get_line(locate(xeno.x, xeno.y, maximum_z), locate(target.x, target.y, maximum_z))
+		for(var/turf/turf_in_path in path)
+			while(istype(turf_in_path, /turf/open_space))
+				turf_in_path = SSmapping.get_turf_below(turf_in_path)
+
+			if(turf_in_path.density && turf_in_path.turf_flags & TURF_HULL)
+				to_chat(xeno, SPAN_WARNING("You can't jump over an object in your path."))
+				return FALSE
+
+			for(var/obj/structure/cur_obj in turf_in_path.contents)
+				if(cur_obj.density && cur_obj.unslashable && cur_obj.unacidable)
+					to_chat(xeno, SPAN_WARNING("You can't jump over an object in your path."))
+					return FALSE
+
+		if(!do_after(xeno, 0.5 SECONDS, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE))
+			return FALSE
+
+	if(target.z != xeno.z && xeno.mob_size >= MOB_SIZE_BIG)
+		if(!do_after(xeno, 2 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
+			return FALSE
+
+	// No windup here - charge was already done during first click
+	xeno.set_face_dir(get_cardinal_dir(xeno, target))
+
+	xeno.visible_message(SPAN_XENOWARNING("[xeno] [action_text][findtext(action_text, "e", -1) || findtext(action_text, "p", -1) ? "s" : "es"] в [target]!"), SPAN_XENOWARNING("Мы [action_text] в [target]!"))
+
+	pre_pounce_effects()
+
+	xeno.pounce_distance = get_dist(xeno, target)
+	if(xeno.z != target.z)
+		xeno.pounce_distance += 2
+	xeno.throw_atom(target, distance, throw_speed, xeno, launch_type = LOW_LAUNCH, pass_flags = pounce_pass_flags, collision_callbacks = pounce_callbacks, tracking=TRUE)
+	xeno.update_icons()
+
+	additional_effects_always()
+
+	return TRUE
+
+/datum/action/xeno_action/activable/pounce/crusher_charge/proc/handle_human_collision(mob/living/carbon/human/human)
+	var/mob/living/carbon/xenomorph/xeno = owner
+
+	playsound(human.loc, "punch", 25, TRUE)
+	human.attack_log += text("\[[time_stamp()]\] <font color='orange'>was crusher charged by [xeno] ([xeno.ckey])</font>")
+	xeno.attack_log += text("\[[time_stamp()]\] <font color='red'>crusher charged [human] ([human.ckey])</font>")
+	log_attack("[xeno] ([xeno.ckey]) crusher charged [human] ([human.ckey])")
+
+	human.take_overall_armored_damage(direct_hit_damage, ARMOR_MELEE, BRUTE, null, 10)
+
+	xeno.visible_message(
+		SPAN_DANGER("[capitalize(xeno.declent_ru(NOMINATIVE))] таранит [human.declent_ru(ACCUSATIVE)]!"),
+		SPAN_XENODANGER("Вы тараните [human.declent_ru(ACCUSATIVE)]!")
+	)
+
+	human.apply_effect(knockdown_duration, WEAKEN)
+	animation_flash_color(human)
+	if(human.client)
+		shake_camera(human, 2, 3)
+
+	var/list/ram_dirs = get_perpen_dir(xeno.dir)
+	var/ram_dir = pick(ram_dirs)
+	var/cur_turf = get_turf(human)
+	var/target_turf = get_step(human, ram_dir)
+	if(LinkBlocked(human, cur_turf, target_turf))
+		ram_dir = REVERSE_DIR(ram_dir)
+	step(human, ram_dir, 2)
+
+/datum/action/xeno_action/activable/pounce/crusher_charge/proc/handle_xeno_collision(mob/living/carbon/xenomorph/target_xeno)
+	var/mob/living/carbon/xenomorph/xeno = owner
+
+	playsound(target_xeno.loc, "punch", 25, TRUE)
+
+	if(!xeno.ally_of_hivenumber(target_xeno.hivenumber))
+		target_xeno.attack_log += text("\[[time_stamp()]\] <font color='orange'>was crusher charged by [xeno] ([xeno.ckey])</font>")
+		xeno.attack_log += text("\[[time_stamp()]\] <font color='red'>crusher charged [target_xeno] ([target_xeno.ckey])</font>")
+		log_attack("[xeno] ([xeno.ckey]) crusher charged [target_xeno] ([target_xeno.ckey])")
+		target_xeno.apply_damage(direct_hit_damage * 0.5, BRUTE)
+
+	if(target_xeno.anchored)
+		return
+
+	if(isqueen(target_xeno) || IS_XENO_LEADER(target_xeno) || isboiler(target_xeno))
+		return
+
+	var/list/ram_dirs = get_perpen_dir(xeno.dir)
+	var/ram_dir = pick(ram_dirs)
+	var/cur_turf = get_turf(target_xeno)
+	var/target_turf = get_step(target_xeno, ram_dir)
+	if(LinkBlocked(target_xeno, cur_turf, target_turf))
+		xeno.emote("roar")
+		xeno.visible_message(
+			SPAN_DANGER("[capitalize(xeno.declent_ru(NOMINATIVE))] отбрасывает [target_xeno.declent_ru(ACCUSATIVE)] в сторону!"),
+			SPAN_DANGER("Вы отбрасываете [target_xeno.declent_ru(ACCUSATIVE)] в сторону!")
+		)
+		to_chat(target_xeno, SPAN_XENOHIGHDANGER("[capitalize(xeno.declent_ru(NOMINATIVE))] отбрасывает вас в сторону! С дороги!"))
+		target_xeno.apply_effect(0.5, WEAKEN)
+		target_xeno.throw_atom(get_turf(target_xeno), 1, 3, xeno, TRUE)
+	else
+		step(target_xeno, ram_dir, 2)
+		target_xeno.apply_effect(0.5, WEAKEN)
+
+/datum/action/xeno_action/activable/pounce/crusher_charge/proc/handle_mob_collision(mob/living/carbon/mob)
+	var/mob/living/carbon/xenomorph/xeno = owner
+
+	playsound(mob.loc, "punch", 25, TRUE)
+	mob.attack_log += text("\[[time_stamp()]\] <font color='orange'>was crusher charged by [xeno] ([xeno.ckey])</font>")
+	xeno.attack_log += text("\[[time_stamp()]\] <font color='red'>crusher charged [mob] ([mob.ckey])</font>")
+	log_attack("[xeno] ([xeno.ckey]) crusher charged [mob] ([mob.ckey])")
+
+	mob.take_overall_damage(direct_hit_damage)
+
+	xeno.visible_message(
+		SPAN_DANGER("[capitalize(xeno.declent_ru(NOMINATIVE))] таранит [mob.declent_ru(ACCUSATIVE)]!"),
+		SPAN_XENODANGER("Вы тараните [mob.declent_ru(ACCUSATIVE)]!")
+	)
+
+	mob.apply_effect(knockdown_duration, WEAKEN)
+	animation_flash_color(mob)
+	if(mob.client)
+		shake_camera(mob, 2, 3)
+
+	var/list/ram_dirs = get_perpen_dir(xeno.dir)
+	var/ram_dir = pick(ram_dirs)
+	var/cur_turf = get_turf(mob)
+	var/target_turf = get_step(mob, ram_dir)
+	if(LinkBlocked(mob, cur_turf, target_turf))
+		ram_dir = REVERSE_DIR(ram_dir)
+	step(mob, ram_dir, 2)
 
 /datum/action/xeno_action/activable/pounce/crusher_charge/initialize_pounce_pass_flags()
 	pounce_pass_flags = PASS_CRUSHER_CHARGE

--- a/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
@@ -24,7 +24,10 @@
 	// Object types that don't reduce cooldown when hit
 	var/list/not_reducing_objects = list()
 	// Two-stage activation
+	var/charge_window = 5 SECONDS
+	var/charge_slowdown = XENO_CRUSHER_CHARGE_SLOWDOWN
 	var/activated_once = FALSE
+	var/slowdown_active = FALSE
 	var/atom/stored_target = null
 	var/charge_timeout_timer_id = TIMER_ID_NULL
 
@@ -50,34 +53,26 @@
 		return
 
 	if(!activated_once)
-		// First click - start charging with windup
 		if(!check_and_use_plasma_owner())
 			return
 
 		xeno.visible_message(SPAN_XENODANGER("[capitalize(xeno.declent_ru(NOMINATIVE))] начинает заряжать рывок!"), SPAN_XENODANGER("Мы начинаем заряжать рывок!"))
 
-		// Lock direction and immobilize during charge
 		xeno.set_face_dir(get_cardinal_dir(xeno, target))
-		ADD_TRAIT(xeno, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Crusher Charge"))
-		xeno.anchored = TRUE
+		apply_charge_slowdown()
 
-		// Apply visual effects (lowered crest)
 		pre_windup_effects()
 
-		// Make crusher jitter during charging
-		var/jitter_duration = round(windup_duration / 0.1) // Convert to ticks (1 tick = 0.1 seconds)
-		xeno.xeno_jitter(jitter_duration)
+		// Jitter runs through windup and the charged wait window, stopped by execute_charge.
+		xeno.xeno_jitter(windup_duration + charge_window)
 
-		// Perform the windup with visual indicator
-		if(!do_after(xeno, windup_duration, INTERRUPT_NO_NEEDHAND, BUSY_ICON_HOSTILE))
+		if(!do_after(xeno, windup_duration, INTERRUPT_INCAPACITATED|INTERRUPT_CHANGED_LYING, BUSY_ICON_HOSTILE))
 			to_chat(xeno, SPAN_XENODANGER("Мы отменяем зарядку рывка!"))
-			REMOVE_TRAIT(xeno, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Crusher Charge"))
-			xeno.anchored = FALSE
+			remove_charge_slowdown()
 			post_windup_effects(interrupted = TRUE)
+			xeno.stop_xeno_jitter()
 			return
 
-		REMOVE_TRAIT(xeno, TRAIT_IMMOBILIZED, TRAIT_SOURCE_ABILITY("Crusher Charge"))
-		xeno.anchored = FALSE
 		// Don't call post_windup_effects here - crest stays lowered until after the charge
 
 		activated_once = TRUE
@@ -86,18 +81,31 @@
 
 		to_chat(xeno, SPAN_XENOWARNING("Рывок заряжен! Выберите направление в течение 5 секунд!"))
 
-		// Set timeout - if no second click in 5 seconds, charge at the first target
-		charge_timeout_timer_id = addtimer(CALLBACK(src, PROC_REF(charge_timeout)), 5 SECONDS, TIMER_STOPPABLE)
+		charge_timeout_timer_id = addtimer(CALLBACK(src, PROC_REF(charge_timeout)), charge_window, TIMER_STOPPABLE)
 		return ..()
 	else
-		// Second click - execute charge at new target immediately (no windup)
 		activated_once = FALSE
 		if(charge_timeout_timer_id != TIMER_ID_NULL)
 			deltimer(charge_timeout_timer_id)
 			charge_timeout_timer_id = TIMER_ID_NULL
 
-		// Call execute_charge to perform the actual charge
 		return execute_charge(target)
+
+/datum/action/xeno_action/activable/pounce/crusher_charge/proc/apply_charge_slowdown()
+	var/mob/living/carbon/xenomorph/xeno = owner
+	if(slowdown_active || !istype(xeno))
+		return
+	xeno.speed_modifier += charge_slowdown
+	xeno.recalculate_speed()
+	slowdown_active = TRUE
+
+/datum/action/xeno_action/activable/pounce/crusher_charge/proc/remove_charge_slowdown()
+	var/mob/living/carbon/xenomorph/xeno = owner
+	if(!slowdown_active || !istype(xeno))
+		return
+	xeno.speed_modifier -= charge_slowdown
+	xeno.recalculate_speed()
+	slowdown_active = FALSE
 
 /datum/action/xeno_action/activable/pounce/crusher_charge/proc/charge_timeout()
 	var/mob/living/carbon/xenomorph/xeno = owner
@@ -109,6 +117,8 @@
 
 	if(!stored_target)
 		to_chat(xeno, SPAN_XENOWARNING("Наш рывок потерял цель!"))
+		xeno.stop_xeno_jitter()
+		remove_charge_slowdown()
 		return
 
 	to_chat(xeno, SPAN_XENOWARNING("Время вышло, мы совершаем рывок в изначальную цель!"))
@@ -116,6 +126,10 @@
 
 /datum/action/xeno_action/activable/pounce/crusher_charge/proc/execute_charge(atom/target)
 	var/mob/living/carbon/xenomorph/xeno = owner
+
+	// Before checks so failed charges also stop the charge-up jitter and slowdown.
+	xeno.stop_xeno_jitter()
+	remove_charge_slowdown()
 
 	if(!target)
 		return FALSE
@@ -175,8 +189,7 @@
 
 	pre_pounce_effects()
 
-	// Set flag that we're in crusher charge mode
-	xeno.status_flags |= CRUSHER_CHARGING
+	ADD_TRAIT(xeno, TRAIT_CRUSHER_CHARGING, TRAIT_SOURCE_ABILITY("Crusher Charge"))
 
 	xeno.pounce_distance = get_dist(xeno, target)
 	if(xeno.z != target.z)
@@ -198,8 +211,7 @@
 
 	UnregisterSignal(xeno, list(COMSIG_MOVABLE_TURF_ENTER, COMSIG_MOVABLE_MOVED))
 
-	// Clear flag after charge actually ends
-	xeno.status_flags &= ~CRUSHER_CHARGING
+	REMOVE_TRAIT(xeno, TRAIT_CRUSHER_CHARGING, TRAIT_SOURCE_ABILITY("Crusher Charge"))
 
 	additional_effects_always()
 
@@ -232,7 +244,7 @@
 
 /datum/action/xeno_action/activable/pounce/crusher_charge/proc/charge_moved(mob/living/carbon/xenomorph/xeno, atom/oldloc, direction, forced)
 	SIGNAL_HANDLER
-	if(!istype(xeno) || !(xeno.status_flags & CRUSHER_CHARGING))
+	if(!istype(xeno) || !HAS_TRAIT(xeno, TRAIT_CRUSHER_CHARGING))
 		return
 
 	// Apply charge collision effects to every mob we moved onto
@@ -355,7 +367,7 @@
 // Override launch_impact for xenomorphs to handle crusher charge
 /mob/living/carbon/xenomorph/launch_impact(atom/hit_atom)
 	// If crusher is charging through mobs, handle collisions differently
-	if(status_flags & CRUSHER_CHARGING && isliving(hit_atom))
+	if(HAS_TRAIT(src, TRAIT_CRUSHER_CHARGING) && isliving(hit_atom))
 		var/datum/action/xeno_action/activable/pounce/crusher_charge/charge_ability = get_action(src, /datum/action/xeno_action/activable/pounce/crusher_charge)
 		if(charge_ability)
 			// Handle the collision but don't stop throwing

--- a/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/crusher/crusher_abilities.dm
@@ -35,7 +35,6 @@
 /datum/action/xeno_action/activable/pounce/crusher_charge/New()
 	. = ..()
 	not_reducing_objects = typesof(/obj/structure/barricade) + typesof(/obj/structure/machinery/defenses)
-	// We'll use signals instead of collision_callbacks for better control
 	pounce_callbacks = list()
 	pounce_callbacks[/obj] = DYNAMIC(/mob/living/carbon/xenomorph/proc/pounced_obj_wrapper)
 	pounce_callbacks[/turf] = DYNAMIC(/mob/living/carbon/xenomorph/proc/pounced_turf_wrapper)
@@ -63,7 +62,6 @@
 
 		pre_windup_effects()
 
-		// Jitter runs through windup and the charged wait window, stopped by execute_charge.
 		xeno.xeno_jitter(windup_duration + charge_window)
 
 		if(!do_after(xeno, windup_duration, INTERRUPT_INCAPACITATED|INTERRUPT_CHANGED_LYING, BUSY_ICON_HOSTILE))
@@ -73,13 +71,11 @@
 			xeno.stop_xeno_jitter()
 			return
 
-		// Don't call post_windup_effects here - crest stays lowered until after the charge
-
 		activated_once = TRUE
 		stored_target = target
 		apply_cooldown()
 
-		to_chat(xeno, SPAN_XENOWARNING("Рывок заряжен! Выберите направление в течение 5 секунд!"))
+		to_chat(xeno, SPAN_XENOWARNING("Рывок заряжен!"))
 
 		charge_timeout_timer_id = addtimer(CALLBACK(src, PROC_REF(charge_timeout)), charge_window, TIMER_STOPPABLE)
 		return ..()
@@ -182,7 +178,6 @@
 		if(!do_after(xeno, 2 SECONDS, INTERRUPT_ALL, BUSY_ICON_HOSTILE))
 			return FALSE
 
-	// No windup here - charge was already done during first click
 	xeno.set_face_dir(get_cardinal_dir(xeno, target))
 
 	xeno.visible_message(SPAN_XENOWARNING("[xeno] [action_text][findtext(action_text, "e", -1) || findtext(action_text, "p", -1) ? "s" : "es"] в [target]!"), SPAN_XENOWARNING("Мы [action_text] в [target]!"))
@@ -215,7 +210,6 @@
 
 	additional_effects_always()
 
-	// Raise the crest after charge is complete
 	post_windup_effects(interrupted = FALSE)
 
 	xeno.update_icons()
@@ -282,7 +276,15 @@
 	xeno.attack_log += text("\[[time_stamp()]\] <font color='red'>crusher charged [human] ([human.ckey])</font>")
 	log_attack("[xeno] ([xeno.ckey]) crusher charged [human] ([human.ckey])")
 
-	human.take_overall_armored_damage(direct_hit_damage, ARMOR_MELEE, BRUTE, null, 10)
+	// Damage to a random limb, with priority of choice like alien_attack
+	var/obj/limb/affecting = human.get_limb(rand_zone("chest", 70))
+	if(!affecting)
+		affecting = human.get_limb(rand_zone(null, 0))
+	if(!affecting)
+		affecting = human.get_limb("chest")
+	var/armor_block = human.getarmor(affecting, ARMOR_MELEE)
+	var/f_damage = armor_damage_reduction(GLOB.marine_melee, direct_hit_damage, armor_block, 10)
+	human.apply_damage(f_damage, BRUTE, affecting)
 
 	xeno.visible_message(
 		SPAN_DANGER("[capitalize(xeno.declent_ru(NOMINATIVE))] таранит [human.declent_ru(ACCUSATIVE)]!"),


### PR DESCRIPTION

## Что этот PR делает
ПР изменяет принцип работы способности крушителя "Charge"

- Замена полного обездвиживания крашера на время зарядки рывка сильным замедлением
- После зарядки (1.2с) цель рывка можно изменить повторным применением абилки. Через 5 секунд, если цель не выбрана, рывок автоматически совершается по изначальной цели
- Мобы больше не останавливают рывок. Все люди на пути получают урон, оглушаются и откидываются в сторону, ксеноморфы получают микростан как от рывка чарджера. Другие твердые препятствия так же блокируют рывок
## Почему это хорошо для игры
[Спросите у Фили](https://discord.com/channels/1097181193939730453/1528156277308526725/1528156277308526725)
## Изображения изменений
https://youtu.be/ftxu28t_EIQ
## Тестирование
Выше
## Changelog
:cl:
balance: Улучшен рывок крашера
/:cl:
