### PR TITLE
Vehicle pamplet fix

### DIFF
--- a/modular/skills/code/pamplets.dm
+++ b/modular/skills/code/pamplets.dm
@@ -7,3 +7,5 @@
 	skill = SKILL_VEHICLE
 	secondary_skill = SKILL_ENGINEER
 	skill_increment = 1
+	skill_cap = SKILL_VEHICLE_SMALL
+	secondary_skill_cap = SKILL_ENGINEER_NOVICE


### PR DESCRIPTION

## Что этот PR делает

Добавляет лимит на инженерный скилл для памплеты вождения.
Fix https://github.com/ss220club/BandaMarines/issues/743
## Почему это хорошо для игры

Да

## Тестирование

Да

## Changelog

:cl:
fix: Исправлена недоработка, позволявшая получить +2 к инженерному навыку комбинацией памплет.
/:cl:
