### PR TITLE
Motorbike balance tweaks

### DIFF
--- a/modular/vehicles/code/motorbike/bike/motorbike_movement.dm
+++ b/modular/vehicles/code/motorbike/bike/motorbike_movement.dm
@@ -70,15 +70,15 @@
 			reset_speed()
 		return ..()
 
+	// Проверка рук (всегда, независимо от навыка)
+	if(user.l_hand && user.r_hand)
+		return ..(user, forward_dir_saved)
+
 	if(!can_drive_one_hand && chance_lost_drive_control_when_one_hand >= 0)
 		// Проверка движения назад
 		var/back_dir = turn(dir, 180)
 		if(direction == back_dir)
 			reset_speed()
-
-		// Проверка рук
-		if(user.l_hand && user.r_hand)
-			return ..(user, forward_dir_saved)
 
 		// С одной рукой - имеешь шанс поменять направление во время дороги
 		if(user.l_hand || user.r_hand)

--- a/modular/vehicles/code/motorbike/bike/motorbike_movement.dm
+++ b/modular/vehicles/code/motorbike/bike/motorbike_movement.dm
@@ -21,6 +21,15 @@
 	/// Запоминаем куда мы ДВИГАЛИСЬ вперед
 	var/forward_dir_saved = SOUTH
 
+	/// Активен ли кулдаун поворотов (когда обе руки заняты)
+	var/turn_cooldown = FALSE
+	/// Длительность кулдауна после совершённого поворота
+	var/turn_cooldown_time = 0.5 SECONDS
+	/// Разрешённое направление движения при активном кулдауне
+	var/allowed_dir = SOUTH
+	/// Флаг, что на этом шаге был совершён поворот (чтобы не обновлять forward_dir_saved)
+	var/turn_just_made = FALSE
+
 	// Система ускорения
 	var/current_speed_level = BIKE_SPEED_MIN
 	var/straight_move_timer = 0
@@ -70,9 +79,28 @@
 			reset_speed()
 		return ..()
 
-	// Проверка рук (всегда, независимо от навыка)
+	// Проверка двух рук – зависит от навыка
 	if(user.l_hand && user.r_hand)
-		return ..(user, forward_dir_saved)
+		if(can_drive_one_hand) // Есть навык – таймер на повороты
+			if(turn_cooldown)
+				// Кулдаун активен – можно двигаться только в allowed_dir
+				if(direction == allowed_dir)
+					return ..(user, direction)  // это прямо, продолжаем
+				else
+					return ..(user, allowed_dir) // попытка поворота – игнорируем, едем прямо
+			else
+				// Кулдауна нет – проверяем, является ли нажатие поворотом
+				if(direction != forward_dir_saved) // Поворот
+					. = ..(user, direction)
+					turn_cooldown = TRUE
+					allowed_dir = direction   // запоминаем новое разрешённое направление
+					turn_just_made = TRUE     // чтобы скорость сбросилась
+					addtimer(CALLBACK(src, PROC_REF(reset_turn_cooldown)), turn_cooldown_time, TIMER_UNIQUE | TIMER_OVERRIDE)
+					return .
+				else
+					return ..(user, direction) // Движение прямо вперёд
+		else // Нет навыка – только прямо (исходное поведение)
+			return ..(user, forward_dir_saved)
 
 	if(!can_drive_one_hand && chance_lost_drive_control_when_one_hand >= 0)
 		// Проверка движения назад
@@ -93,12 +121,15 @@
 				lost_drive_control_time_temp = 0
 				to_chat(user, SPAN_NOTICE("Вы восстановили управление!"))
 
-	// Движение вперед
+	/// Движение вперед
 	set_glide_size(DELAY_TO_GLIDE_SIZE(move_delay + 1))
 	. = ..()
 	if(.)
-		forward_dir = dir // Обновление направления движения при любом успешном перемещении
-		handle_acceleration() // Обновление ускорения после поворота
+		forward_dir = dir
+		handle_acceleration()
+
+/obj/vehicle/motorbike/proc/reset_turn_cooldown()
+	turn_cooldown = FALSE
 
 // ==========================================
 // ================ Скорость ================
@@ -146,7 +177,9 @@
 
 	last_move_time = current_time
 
-	forward_dir_saved = forward_dir
+	if(!turn_just_made)
+		forward_dir_saved = forward_dir
+	turn_just_made = FALSE
 
 // ==========================================
 // ========== Движение с коляской ===========

--- a/modular/vehicles/code/motorbike/bike/motorbike_movement.dm
+++ b/modular/vehicles/code/motorbike/bike/motorbike_movement.dm
@@ -27,8 +27,6 @@
 	var/turn_cooldown_time = 0.5 SECONDS
 	/// Разрешённое направление движения при активном кулдауне
 	var/allowed_dir = SOUTH
-	/// Флаг, что на этом шаге был совершён поворот (чтобы не обновлять forward_dir_saved)
-	var/turn_just_made = FALSE
 
 	// Система ускорения
 	var/current_speed_level = BIKE_SPEED_MIN
@@ -84,17 +82,13 @@
 		if(can_drive_one_hand) // Есть навык – таймер на повороты
 			if(turn_cooldown)
 				// Кулдаун активен – можно двигаться только в allowed_dir
-				if(direction == allowed_dir)
-					return ..(user, direction)  // это прямо, продолжаем
-				else
-					return ..(user, allowed_dir) // попытка поворота – игнорируем, едем прямо
+				return ..(user, allowed_dir) // попытка поворота – игнорируем, едем прямо
 			else
 				// Кулдауна нет – проверяем, является ли нажатие поворотом
 				if(direction != forward_dir_saved) // Поворот
 					. = ..(user, direction)
 					turn_cooldown = TRUE
 					allowed_dir = direction   // запоминаем новое разрешённое направление
-					turn_just_made = TRUE     // чтобы скорость сбросилась
 					addtimer(CALLBACK(src, PROC_REF(reset_turn_cooldown)), turn_cooldown_time, TIMER_UNIQUE | TIMER_OVERRIDE)
 					return .
 				else
@@ -177,9 +171,8 @@
 
 	last_move_time = current_time
 
-	if(!turn_just_made)
-		forward_dir_saved = forward_dir
-	turn_just_made = FALSE
+	forward_dir_saved = forward_dir
+
 
 // ==========================================
 // ========== Движение с коляской ===========

--- a/modular/vehicles/code/motorbike/bike/motorbike_movement.dm
+++ b/modular/vehicles/code/motorbike/bike/motorbike_movement.dm
@@ -24,9 +24,11 @@
 	/// Активен ли кулдаун поворотов (когда обе руки заняты)
 	var/turn_cooldown = FALSE
 	/// Длительность кулдауна после совершённого поворота
-	var/turn_cooldown_time = 0.5 SECONDS
+	var/turn_cooldown_time = 0.4 SECONDS
 	/// Разрешённое направление движения при активном кулдауне
 	var/allowed_dir = SOUTH
+	/// Модификатор скорости при движении по траве
+	var/weed_speed_mod = 1.5
 
 	// Система ускорения
 	var/current_speed_level = BIKE_SPEED_MIN
@@ -76,6 +78,8 @@
 		if(current_speed_level != BIKE_SPEED_MIN)
 			reset_speed()
 		return ..()
+
+	update_speed() // скорость пересчитывается перед каждым движением
 
 	// Проверка двух рук – зависит от навыка
 	if(user.l_hand && user.r_hand)
@@ -138,6 +142,8 @@
 			move_delay = move_delay_maximum
 	if(!sidecar)
 		move_delay *= lightweight_speed_mod
+	if(locate(/obj/effect/alien/weeds) in loc)
+		move_delay *= weed_speed_mod
 
 /obj/vehicle/motorbike/proc/reset_speed()
 	straight_move_timer = 0

--- a/modular/vehicles/code/motorbike/sidecar/passenger/passenger_guns.dm
+++ b/modular/vehicles/code/motorbike/sidecar/passenger/passenger_guns.dm
@@ -18,17 +18,17 @@
 /obj/structure/machinery/m56d_hmg/low
 	// Стрельба
 	shoot_degree = 65
-	fire_delay = 0.4 SECONDS
-	burst_fire_delay = 0.3 SECONDS
-	autofire_slow_mult = 1.2
+	fire_delay = 0.3 SECONDS
+	burst_fire_delay = 0.2 SECONDS
+	autofire_slow_mult = 1
 
 /obj/structure/machinery/m56d_hmg/auto/low
 	// Стрельба
 	shoot_degree = 45
-	fire_delay = 0.2 SECONDS
+	fire_delay = 0.1 SECONDS
 	burst_fire_delay = 0.25 SECONDS
 	cadeblockers_range = 0
-	autofire_slow_mult = 1.2
+	autofire_slow_mult = 1
 
 // ==========================================
 // ============== Безопасность ==============


### PR DESCRIPTION

## Что этот PR делает

Переносит проверку рук при управлении мотоциклом, так чтобы при занятых руках направление движения блокировалось всегда, так же при блоке направления движения нет ускорения, но так и было вроде.
## Почему это хорошо для игры

Теперь нельзя рулить неприличными местами и стрелять одновременно, и придется освобождать одну руку для поворотов, что логично.


## Тестирование

Да, но лучше еще потестить

## Changelog
:cl:
fix: Теперь нельзя менять направление движения мотоцикла с занятыми руками.
/:cl:
