### PR TITLE
CLF Base remaps

### DIFF
--- a/maps/map_files/BigRed/standalone/clfmining.dmm
+++ b/maps/map_files/BigRed/standalone/clfmining.dmm
@@ -753,6 +753,8 @@
 /obj/structure/surface/rack,
 /obj/effect/landmark/good_item,
 /obj/item/stack/sheet/metal/small_stack,
+/obj/item/stack/sheet/metal/small_stack,
+/obj/item/stack/sheet/metal/small_stack,
 /turf/open/floor/plating/platingdmg3/west,
 /area/bigredv2/caves/mining)
 "lD" = (
@@ -3086,6 +3088,12 @@
 /obj/effect/landmark/objective_landmark/medium,
 /turf/open/floor/plating/platingdmg3/west,
 /area/bigredv2/caves/mining)
+"Wv" = (
+/obj/item/tool/shovel/snow{
+	pixel_y = 5
+	},
+/turf/open/mars_cave/mars_dirt_7,
+/area/bigredv2/caves/mining)
 "Wy" = (
 /obj/structure/surface/table,
 /obj/item/folder/black_random,
@@ -4007,7 +4015,7 @@ LB
 bi
 AV
 mz
-lK
+Wv
 Oc
 lK
 FO

--- a/maps/map_files/DesertDam/standalone/clfpods.dmm
+++ b/maps/map_files/DesertDam/standalone/clfpods.dmm
@@ -929,6 +929,13 @@
 	},
 /turf/open/asphalt/cement_sunbleached/cement_sunbleached16,
 /area/desert_dam/exterior/valley/valley_medical)
+"lt" = (
+/obj/structure/flora/grass/desert/heavygrass_3,
+/obj/structure/machinery/defenses/sentry/premade/lowammo/random/dumb{
+	dir = 8
+	},
+/turf/open/desert/dirt,
+/area/desert_dam/exterior/valley/valley_medical)
 "lA" = (
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal4"
@@ -1136,6 +1143,10 @@
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
 "tv" = (
+/obj/item/stack/sandbags_empty/full{
+	pixel_y = -6
+	},
+/obj/item/stack/sandbags_empty/full,
 /turf/open/desert/dirt/desert_transition_corner1/east,
 /area/desert_dam/exterior/valley/valley_medical)
 "tC" = (
@@ -1811,6 +1822,9 @@
 /obj/effect/decal/medical_decals{
 	icon_state = "docdecal3"
 	},
+/obj/structure/machinery/defenses/sentry/premade/lowammo/random/dumb{
+	dir = 8
+	},
 /turf/open/floor/white,
 /area/desert_dam/building/medical/garage)
 "Nx" = (
@@ -1974,6 +1988,16 @@
 /turf/open/asphalt,
 /area/desert_dam/exterior/valley/valley_medical)
 "RM" = (
+/obj/item/tool/shovel/snow{
+	pixel_y = 5
+	},
+/obj/item/stack/sheet/metal/large_stack{
+	pixel_x = 8
+	},
+/obj/item/stack/sheet/metal/large_stack{
+	pixel_y = 9;
+	pixel_x = 10
+	},
 /turf/open/desert/dirt/desert_transition_edge1/southwest,
 /area/desert_dam/exterior/valley/valley_medical)
 "RY" = (
@@ -2397,7 +2421,7 @@ zh
 vp
 vp
 vp
-io
+lt
 vp
 vp
 we

--- a/maps/map_files/Kutjevo/standalone/clfsmugglers.dmm
+++ b/maps/map_files/Kutjevo/standalone/clfsmugglers.dmm
@@ -234,6 +234,25 @@
 	},
 /turf/open/asphalt/cement_sunbleached,
 /area/kutjevo/interior/colony/landing_zone_checkpoint)
+"kb" = (
+/obj/item/stack/sandbags_empty/small_stack{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/item/stack/sandbags_empty/small_stack,
+/obj/item/stack/sandbags_empty/small_stack{
+	pixel_y = 11;
+	pixel_x = -3
+	},
+/obj/item/tool/shovel/snow{
+	pixel_y = 5
+	},
+/obj/item/stack/sandbags/small_stack{
+	pixel_y = -6;
+	pixel_x = -15
+	},
+/turf/open/auto_turf/sand/layer1,
+/area/kutjevo/exterior/clf_lz)
 "kM" = (
 /obj/structure/shuttle/part/ert/transparent/right_engine,
 /turf/open/floor/plating/kutjevo,
@@ -675,6 +694,7 @@
 /area/kutjevo/exterior/clf_lz)
 "HK" = (
 /obj/structure/largecrate,
+/obj/item/ammo_box/magazine/mar30,
 /turf/open/floor/almayer/research/containment/floor2,
 /area/kutjevo/exterior/clf_lz)
 "Ix" = (
@@ -1642,7 +1662,7 @@ qx
 sz
 dT
 cf
-cf
+kb
 cf
 fK
 ZQ

--- a/maps/map_files/LV624/standalone/clfship.dmm
+++ b/maps/map_files/LV624/standalone/clfship.dmm
@@ -243,6 +243,7 @@
 "aP" = (
 /obj/item/stack/sheet/metal/large_stack,
 /obj/structure/closet/coffin/woodencrate,
+/obj/item/stack/sheet/plasteel/med_large_stack,
 /turf/open/gm/dirt,
 /area/lv624/ground/caves/south_west_caves)
 "aQ" = (
@@ -1021,6 +1022,25 @@
 	},
 /turf/open/floor/wood,
 /area/lv624/lazarus/crashed_ship)
+"yI" = (
+/obj/item/stack/sandbags_empty/small_stack{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/item/stack/sandbags_empty/small_stack,
+/obj/item/stack/sandbags_empty/small_stack{
+	pixel_y = 11;
+	pixel_x = -3
+	},
+/obj/item/tool/shovel/snow{
+	pixel_y = 5
+	},
+/obj/item/stack/sandbags/small_stack{
+	pixel_y = -6;
+	pixel_x = -15
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
 "yT" = (
 /obj/structure/barricade/metal/wired{
 	icon_state = "metal_2"
@@ -1093,6 +1113,14 @@
 /obj/item/ammo_magazine/pistol/heavy,
 /turf/open/floor/almayer/green/northeast,
 /area/lv624/lazarus/crashed_ship)
+"AM" = (
+/obj/structure/barricade/plasteel/wired{
+	icon_state = "plasteel_3";
+	density = 1;
+	closed = 0
+	},
+/turf/open/gm/dirt,
+/area/lv624/ground/caves/south_west_caves)
 "AP" = (
 /obj/structure/cargo_container/arious/right,
 /turf/open/floor/platingdmg1,
@@ -2673,7 +2701,7 @@ Qf
 CO
 Ab
 Ab
-Ab
+aV
 uq
 Hj
 Hj
@@ -2720,7 +2748,7 @@ bP
 vf
 Ab
 Ab
-Ab
+AM
 Ab
 Ab
 xu
@@ -2767,7 +2795,7 @@ bP
 CO
 Ab
 Ab
-Ab
+AM
 Ab
 Ab
 xu
@@ -2814,7 +2842,7 @@ ro
 xG
 Ab
 Ab
-Ab
+aV
 Ab
 uq
 xu
@@ -2861,7 +2889,7 @@ Bc
 pq
 Ab
 Ab
-Ab
+aV
 Ab
 Ab
 xu
@@ -2908,7 +2936,7 @@ mS
 pq
 Ab
 Ab
-Ab
+aV
 Ab
 Ab
 xu
@@ -2955,7 +2983,7 @@ Kt
 VF
 Ab
 Ab
-Ab
+aV
 uq
 xu
 Yj
@@ -3046,7 +3074,7 @@ VX
 iq
 BC
 ZS
-ac
+yI
 ad
 ab
 Hj
@@ -3643,9 +3671,9 @@ Hj
 aT
 aT
 aT
-Ab
-Ab
-Ab
+jz
+aL
+aL
 Ab
 aA
 Ab
@@ -3693,7 +3721,7 @@ Ab
 Ab
 Ab
 Ab
-Ab
+aD
 Hj
 Hj
 Hj

--- a/maps/map_files/Sorokyne_Strata/standalone/clfcamp.dmm
+++ b/maps/map_files/Sorokyne_Strata/standalone/clfcamp.dmm
@@ -2451,6 +2451,11 @@
 	},
 /turf/open/gm/river/soro,
 /area/strata/exterior/far_north_outpost)
+"Yg" = (
+/obj/structure/largecrate/supply,
+/obj/item/ammo_box/magazine/mar30,
+/turf/open/floor/strata/multi_tiles/southeast,
+/area/strata/interior/outpost/clf_dorms)
 "Yr" = (
 /obj/structure/surface/rack,
 /obj/item/weapon/gun/pistol/t73,
@@ -3248,7 +3253,7 @@ pb
 cH
 cH
 cH
-Ld
+Yg
 GJ
 Sl
 cW


### PR DESCRIPTION

## Что этот PR делает
Улучшает обороноспособность КЛФ на их спавнах
Биг Ред/Кутьево/ Солярис ридж/Дамба КЛФ добавлены пустые мешки с песками, лопатка и коробка патрон для мар 30.
## Почему это хорошо для игры
КЛФ должны создавать интерес для обоих сторон, а не как обычные сурвы убегать в угол карты чтобы держать до маров, которых атаковать в спину. Попытка создать благоприятные условия для обороны КЛФ, но без возможности использовать это в атаке
## Изображения изменений
## Тестирование
## Changelog
:cl:

map: Изменены инсерты КЛФ
/:cl:
