### PR TITLE
Remove VPN-related Admin buttons.

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -101,8 +101,8 @@ GLOBAL_LIST_INIT(admin_verbs_admin, list(
 GLOBAL_LIST_INIT(admin_verbs_ban, list(
 	/client/proc/unban_panel,
 	/client/proc/stickyban_panel,
-	/client/proc/ipcheck_allow,
-	/client/proc/ipcheck_revoke,
+	// /client/proc/ipcheck_allow, // SS220 EDIT
+	// /client/proc/ipcheck_revoke, // SS220 EDIT
 	// /client/proc/jobbans // Disabled temporarily due to 15-30 second lag spikes.
 ))
 


### PR DESCRIPTION

## Что этот PR делает
Убирает админ кнопки связанные с выдачей Вайтлиста на VPN
## Почему это хорошо для игры
Попросили убрать из-за ненадобности.

## Changelog
:cl:

del: Админ кнопки связанные с выдачей Вайтлиста для VPN были скрыты.

/:cl:
