### PR TITLE
Add player donator levels from Central

### DIFF
--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -30,6 +30,7 @@
 	var/time_died_as_mouse = null //when the client last died as a mouse
 
 	var/donator = FALSE
+	var/donator_level = 0 // BANDAMARINES EDIT: Central benefit tier
 	var/adminhelped = 0
 
 	var/datum/click_intercept = null

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -454,6 +454,10 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	if(holder)
 		INVOKE_ASYNC(holder, TYPE_PROC_REF(/datum/admins, associate), src)
 
+	// BANDAMARINES EDIT START: Central benefit tier
+	if(CONFIG_GET(string/central_api_url))
+		donator_level = SScentral.get_player_donate_tier_blocking(src)
+	// BANDAMARINES EDIT END: Central benefit tier
 	add_pref_verbs()
 	//preferences datum - also holds some persistent data for the client (because we may as well keep these datums to a minimum)
 	prefs = GLOB.preferences_datums[ckey]
@@ -1036,6 +1040,18 @@ CLIENT_VERB(action_hide_menu)
 	if(!selected_action.player_hidden && selected_action.hidden) //Inform the player that even if they are unhiding it, itll still not be visible
 		to_chat(user, SPAN_NOTICE("[selected_action] is forcefully hidden, bypassing player unhiding."))
 
+
+// BANDAMARINES EDIT START: Central benefit tier
+/client/proc/get_donator_level()
+	var/datum/admins/admin = GLOB.admin_datums[ckey]
+	return max(donator_level, (admin?.rights & R_HOST) ? 5 : 0)
+
+// Only host can edit donator level
+/client/vv_edit_var(var_name, var_value)
+	if(var_name == NAMEOF(src, donator_level) && !CLIENT_HAS_RIGHTS(usr?.client, R_HOST))
+		return FALSE
+	return ..()
+// BANDAMARINES EDIT END: Central benefit tier
 
 /client/proc/check_whitelist_status(flag_to_check)
 	if(check_localhost_status())

--- a/modular/metaserver/code/ss_central.dm
+++ b/modular/metaserver/code/ss_central.dm
@@ -48,12 +48,13 @@ SUBSYSTEM_DEF(central)
 	return FALSE
 
 /datum/controller/subsystem/central/proc/get_player_donate_tier_blocking(client/player)
-	var/endpoint = "[CONFIG_GET(string/central_api_url)]/donates?ckey=[player.ckey]&active_only=true&page=1&page_size=1"
+	var/endpoint = "[CONFIG_GET(string/central_api_url)]/donates?ckey=[player.ckey]&active_only=true&page=1&page_size=50"
 	var/datum/http_response/response = SShttp.make_sync_request(RUSTG_HTTP_METHOD_GET, endpoint, "", list())
 	if(response.errored || response.status_code != 200)
 		stack_trace("Failed to get player donate tier: HTTP status code [response.status_code] - [response.error] - [response.body]")
-		return 0
+		return player.donator_level
 
 	var/list/data = json_decode(response.body)
-	if(length(data["items"]))
-		return data["items"][1]["tier"]
+	. = 0
+	for(var/list/item in data["items"])
+		. = max(., item["tier"])


### PR DESCRIPTION

## Что этот PR делает
Добавляет `donator_level` для клиентов с загрузкой из Централа при входе. Выбирается максимальный тир среди первых 50 активных льгот.
Добавляет `get_donator_level()` для использования в игровом коде. Хосту возвращается уровень т5.
Отключает возможность редактирования `donation_level` в vv без наличия прав хоста.

## Почему это хорошо для игры
Позволяет игровым механикам использовать уровень льгот из Централа с учётом межсерверных донатов.

## Изображения изменений
<img width="1281" height="877" alt="image" src="https://github.com/user-attachments/assets/7708a3b8-67b9-45d7-b4dd-368731768b98" />
<img width="1116" height="100" alt="image" src="https://github.com/user-attachments/assets/59a9eae1-4ed3-4e86-bf5f-763c3182bbaf" />


## Тестирование
Локальный компил, т5 для хоста при проверке тира, изолировано проверены запросы с ответами тестового централа, максимум среди страницы льгот, понижение тира, пустой ответ.

## Changelog
:cl:
code_imp: Добавлена поддержка донатных тиров для использования в игровом коде.
/:cl:
